### PR TITLE
[Feat] 게시물 생성 구현

### DIFF
--- a/cohobby/build.gradle
+++ b/cohobby/build.gradle
@@ -26,15 +26,14 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/cohobby/src/main/java/com/backthree/cohobby/CohobbyApplication.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/CohobbyApplication.java
@@ -1,8 +1,11 @@
 package com.backthree.cohobby;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class CohobbyApplication {
 

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/category/entity/Category.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/category/entity/Category.java
@@ -1,5 +1,6 @@
 package com.backthree.cohobby.domain.category.entity;
 
+import com.backthree.cohobby.domain.common.BaseTimeEntity;
 import com.backthree.cohobby.domain.hobby.entity.Hobby;
 import jakarta.persistence.*;
 import lombok.*;
@@ -12,7 +13,7 @@ import java.util.Set;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Category {
+public class Category extends BaseTimeEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/chatting/entity/Chatting.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/chatting/entity/Chatting.java
@@ -31,21 +31,4 @@ public class Chatting extends BaseTimeEntity {
     @JoinColumn(name = "receiverId", nullable = false)
     private User receiver;
 
-    @NotNull
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "receiver_id", nullable = false)
-    private User receiver1;
-
-    @NotNull
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "sender_id", nullable = false)
-    private User sender1;
-
-    public void setSender1(User sender1) {
-        this.sender1 = sender1;
-    }
-
-    public void setReceiver1(User receiver1) {
-        this.receiver1 = receiver1;
-    }
 }

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/common/BaseTimeEntity.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/common/BaseTimeEntity.java
@@ -17,8 +17,8 @@ public class BaseTimeEntity {
 
     @CreatedDate
     @Column(updatable = false)
-    private LocalDateTime createdDate;
+    private LocalDateTime createdAt;
 
     @LastModifiedDate
-    private LocalDateTime lastModifiedDate;
+    private LocalDateTime updatedAt;
 }

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/hobby/entity/Hobby.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/hobby/entity/Hobby.java
@@ -35,11 +35,4 @@ public class Hobby extends BaseTimeEntity {
     @OneToMany(mappedBy = "hobby")
     private Set<Post> posts = new LinkedHashSet<>();
 
-    public void setPosts(Set<Post> posts) {
-        this.posts = posts;
-    }
-
-    public void setContributions(Set<Contribution> contributions) {
-        this.contributions = contributions;
-    }
 }

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/like/entity/Like.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/like/entity/Like.java
@@ -9,19 +9,19 @@ import lombok.Setter;
 @Getter
 @Setter
 @Entity
-@Table(name = "likes", schema = "cohobby")
+@Table(name = "likes",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "post_id"}))
 public class Like {
-    @Id
-    private Long id;
 
-    @MapsId("userId")
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;   // 단일 PK
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @MapsId("postId")
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
-
 }

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/post/controller/PostController.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/post/controller/PostController.java
@@ -1,0 +1,43 @@
+package com.backthree.cohobby.domain.post.controller;
+
+import com.backthree.cohobby.domain.post.dto.request.CreatePostRequest;
+import com.backthree.cohobby.domain.post.dto.response.CreatePostResponse;
+import com.backthree.cohobby.domain.post.service.PostService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name="Post", description = "게시물 관련 API")
+@RestController
+@RequestMapping("/posts")
+@RequiredArgsConstructor
+public class PostController {
+    private final PostService postService;
+
+    @Operation(summary = "게시글 초안 생성", description = "물품 정보 입력을 시작할 때 게시글의 초기 DRAFT 상태를 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode="201", description="게시물 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "존재하지 않는 유저/취미 ID")
+    })
+    @PostMapping()
+    public ResponseEntity<CreatePostResponse> createPost(
+            @Valid @RequestBody CreatePostRequest request   // JSON 본문을 받기 위해 @RequestBody 사용, 유효성 검사를 위해 @Valid 추가
+    ) {
+        CreatePostResponse response = postService.createPost(request);
+
+        // HTTP 상태 201 Created 와 함께 응답 반환
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/post/dto/request/CreatePostRequest.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/post/dto/request/CreatePostRequest.java
@@ -1,0 +1,26 @@
+package com.backthree.cohobby.domain.post.dto.request;
+
+
+import com.backthree.cohobby.domain.category.entity.Category;
+import com.backthree.cohobby.domain.hobby.entity.Hobby;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Getter
+@Setter
+public class CreatePostRequest {
+    @Schema(description = "상품명", example = "나이키 에어포스")
+    @NotBlank(message = "상품명은 필수 입력 값입니다.")
+    private String goods;
+
+    @Schema(description= "userId", example = "1")
+    @NotNull()
+    private Long userId;
+
+    @Schema(description = "취미 ID", example = "5")
+    @NotNull(message = "취미는 필수 선택 값입니다.")
+    private Long hobbyId;
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/post/dto/response/CreatePostResponse.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/post/dto/response/CreatePostResponse.java
@@ -1,0 +1,19 @@
+package com.backthree.cohobby.domain.post.dto.response;
+
+import com.backthree.cohobby.domain.post.entity.Post;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+
+@Getter
+@Builder
+public class CreatePostResponse {
+    @Schema(description = "생성된 게시물 ID", example = "123")
+    private Long postId;
+    public static CreatePostResponse fromEntity(Post post){
+        return CreatePostResponse.builder()
+                .postId(post.getId())
+                .build();
+    }
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/post/entity/Post.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/post/entity/Post.java
@@ -19,8 +19,8 @@ public class Post extends BaseTimeEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 127)
-    private String title;
+    @Column(length = 63)
+    private String goods;
 
     @Column(length = 500)
     private String description;
@@ -31,12 +31,20 @@ public class Post extends BaseTimeEntity {
     @Column(name = "image_url", length = 255)
     private String imageUrl;
 
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private PostStatus status = PostStatus.DRAFT;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "hobbyId")
     private Hobby hobby;
 
     @OneToMany(mappedBy = "post")
     private Set<Image> images = new LinkedHashSet<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     @ManyToMany
     @JoinTable(name = "likes",
@@ -47,15 +55,4 @@ public class Post extends BaseTimeEntity {
     @OneToMany(mappedBy = "post")
     private Set<Rent> rents = new LinkedHashSet<>();
 
-    public void setRents(Set<Rent> rents) {
-        this.rents = rents;
-    }
-
-    public void setUsers(Set<User> users) {
-        this.users = users;
-    }
-
-    public void setImages(Set<Image> images) {
-        this.images = images;
-    }
 }

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/post/entity/PostStatus.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/post/entity/PostStatus.java
@@ -1,0 +1,13 @@
+package com.backthree.cohobby.domain.post.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PostStatus {
+    DRAFT ("DRAFT"),
+    PUBLISHED ("PUBLISHED"),
+    ARCHIVED("ARCHIVED");
+    private final String value;
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/post/repository/PostRepository.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/post/repository/PostRepository.java
@@ -2,6 +2,8 @@ package com.backthree.cohobby.domain.post.repository;
 
 import com.backthree.cohobby.domain.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 }

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/post/service/PostService.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/post/service/PostService.java
@@ -1,0 +1,49 @@
+package com.backthree.cohobby.domain.post.service;
+
+import com.backthree.cohobby.domain.hobby.entity.Hobby;
+import com.backthree.cohobby.domain.hobby.repository.HobbyRepository;
+import com.backthree.cohobby.domain.post.dto.request.CreatePostRequest;
+import com.backthree.cohobby.domain.post.dto.response.CreatePostResponse;
+import com.backthree.cohobby.domain.post.entity.Post;
+import com.backthree.cohobby.domain.post.repository.PostRepository;
+import com.backthree.cohobby.domain.user.entity.User;
+import com.backthree.cohobby.domain.user.repository.UserRepository;
+import com.backthree.cohobby.global.exception.GeneralException;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import com.backthree.cohobby.global.common.response.status.ErrorStatus;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final HobbyRepository hobbyRepository;
+
+    private static final Long DUMMY_USER_ID = 1L;  //임시 유저
+
+    @Transactional
+    public CreatePostResponse createPost(CreatePostRequest request){
+        // ID를 기반으로 각 엔티티가 존재하는지 조회
+        // 더미 유저 조회 (없으면 예외)
+        User user = userRepository.findById(DUMMY_USER_ID)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND, "id=" + request.getUserId()));
+        Hobby hobby = hobbyRepository.findById(request.getHobbyId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.HOBBY_NOT_FOUND,"id=" + request.getHobbyId()));
+
+        // Post 엔티티 생성
+        Post newPost = Post.builder()
+                .goods(request.getGoods())
+                .user(user)
+                .hobby(hobby)
+                .build();
+
+        // 생성된 Post 엔티티를 Repository에 저장
+        Post savedPost = postRepository.save(newPost);
+
+        return CreatePostResponse.fromEntity(savedPost);
+    }
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/rent/alert/entity/RentAlert.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/rent/alert/entity/RentAlert.java
@@ -39,21 +39,4 @@ public class RentAlert extends BaseTimeEntity {
     @JoinColumn(name = "userId", nullable = false)
     private User user;
 
-    @NotNull
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "rent_id", nullable = false)
-    private Rent rent1;
-
-    @NotNull
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user1;
-
-    public void setUser1(User user1) {
-        this.user1 = user1;
-    }
-
-    public void setRent1(Rent rent1) {
-        this.rent1 = rent1;
-    }
 }

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/rent/entity/Rent.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/rent/entity/Rent.java
@@ -54,21 +54,6 @@ public class Rent extends BaseTimeEntity {
     @JoinColumn(name = "postId", nullable = false)
     private Post post;
 
-    @NotNull
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "borrower_id", nullable = false)
-    private User borrower1;
-
-    @NotNull
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "owner_id", nullable = false)
-    private User owner1;
-
-    @NotNull
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "post_id", nullable = false)
-    private Post post1;
-
     @OneToMany(mappedBy = "rent")
     private Set<Payment> payments = new LinkedHashSet<>();
 
@@ -81,31 +66,4 @@ public class Rent extends BaseTimeEntity {
     @OneToMany(mappedBy = "rent")
     private Set<Review> reviews = new LinkedHashSet<>();
 
-    public void setReviews(Set<Review> reviews) {
-        this.reviews = reviews;
-    }
-
-    public void setReports(Set<Report> reports) {
-        this.reports = reports;
-    }
-
-    public void setRentAlerts(Set<RentAlert> rentAlerts) {
-        this.rentAlerts = rentAlerts;
-    }
-
-    public void setPayments(Set<Payment> payments) {
-        this.payments = payments;
-    }
-
-    public void setPost1(Post post1) {
-        this.post1 = post1;
-    }
-
-    public void setOwner1(User owner1) {
-        this.owner1 = owner1;
-    }
-
-    public void setBorrower1(User borrower1) {
-        this.borrower1 = borrower1;
-    }
 }

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/report/entity/Report.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/report/entity/Report.java
@@ -39,21 +39,4 @@ public class Report extends BaseTimeEntity {
     @JoinColumn(name = "userId", nullable = false)
     private User user;
 
-    @NotNull
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "rent_id", nullable = false)
-    private Rent rent1;
-
-    @NotNull
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user1;
-
-    public void setUser1(User user1) {
-        this.user1 = user1;
-    }
-
-    public void setRent1(Rent rent1) {
-        this.rent1 = rent1;
-    }
 }

--- a/cohobby/src/main/java/com/backthree/cohobby/global/common/BaseResponse.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/global/common/BaseResponse.java
@@ -9,9 +9,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 import java.util.Collections;
 
+@Getter
 @AllArgsConstructor(access= AccessLevel.PRIVATE)
 @JsonPropertyOrder({"isSuccess","code","message","result"})
 public class BaseResponse<T> {

--- a/cohobby/src/main/java/com/backthree/cohobby/global/common/response/code/ErrorReasonDTO.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/global/common/response/code/ErrorReasonDTO.java
@@ -11,4 +11,5 @@ public class ErrorReasonDTO {
     private final boolean isSuccess;
     private final String code;
     private final String message;
+
 }

--- a/cohobby/src/main/java/com/backthree/cohobby/global/common/response/status/ErrorStatus.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/global/common/response/status/ErrorStatus.java
@@ -10,13 +10,19 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorStatus implements BaseErrorCode {
     // 기본 에러
-    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
-    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
-    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
-    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
     INVALID_REQUEST_INFO(HttpStatus.BAD_REQUEST, "COMMON404", "요청된 정보가 올바르지 않습니다."),
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "COMMON405", "유효성 검증에 실패했습니다."),
-    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "COMMON405", "유효하지 않은 파라미터입니다.");
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "COMMON405", "유효하지 않은 파라미터입니다."),
+
+    //user 관련 에러
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404", "유저를 찾을 수 없습니다"),
+
+    //hobby 관련 에러
+    HOBBY_NOT_FOUND(HttpStatus.NOT_FOUND,"HOBBY404", "취미를 찾을 수 없습니다");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/cohobby/src/main/java/com/backthree/cohobby/global/config/swagger/SwaggerConfig.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/global/config/swagger/SwaggerConfig.java
@@ -1,7 +1,59 @@
 package com.backthree.cohobby.global.config.swagger;
 
-import org.springframework.context.annotation.Configuration;
-@Configuration
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        servers = {
+                @Server(url = "http://localhost:8080", description = "로컬 서버")
+        })
 public class SwaggerConfig {
+    @Bean
+    public OpenAPI catchyApi() {
+        return new OpenAPI()
+                .info(apiInfo())
+                .components(authSetting())
+                .addSecurityItem(securityRequirement());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("CoHobby")
+                .description("Cohobby API 명세서")
+                .version("1.0.0");
+    }
+
+    SecurityScheme accessTokenSecurityScheme = new SecurityScheme()
+            .type(SecurityScheme.Type.HTTP)
+            .scheme("bearer")
+            .bearerFormat("JWT")
+            .in(SecurityScheme.In.HEADER)
+            .name("Authorization");
+
+    SecurityScheme refreshTokenSecurityScheme = new SecurityScheme()
+            .type(SecurityScheme.Type.APIKEY)
+            .in(SecurityScheme.In.HEADER)
+            .name("Refresh-Token");
+
+    private Components authSetting() {
+        return new Components()
+                .addSecuritySchemes("accessToken", accessTokenSecurityScheme)
+                .addSecuritySchemes("refreshToken", refreshTokenSecurityScheme);
+    }
+
+    private SecurityRequirement securityRequirement() {
+        SecurityRequirement securityRequirement = new SecurityRequirement();
+        securityRequirement.addList("accessToken");
+        securityRequirement.addList("refreshToken");
+        return securityRequirement;
+    }
 }

--- a/cohobby/src/main/java/com/backthree/cohobby/global/exception/GeneralException.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/global/exception/GeneralException.java
@@ -1,0 +1,43 @@
+package com.backthree.cohobby.global.exception;
+
+import com.backthree.cohobby.global.common.response.code.BaseErrorCode;
+import com.backthree.cohobby.global.common.response.code.ErrorReasonDTO;
+import com.backthree.cohobby.global.common.response.status.ErrorStatus;
+import lombok.Getter;
+
+
+@Getter
+public class GeneralException extends RuntimeException {
+
+    private BaseErrorCode code;
+    private String additionalMessage; // 추가 메시지 필드
+
+    // 기본 생성자 (추가 메시지 없이 사용)
+    public GeneralException(BaseErrorCode code) {
+        super(code.getReason().getMessage());
+        this.code = code;
+        this.additionalMessage = null; // 추가 메시지는 null로 초기화
+    }
+
+    // 추가 메시지를 포함하는 생성자
+    public GeneralException(BaseErrorCode code, String additionalMessage) {
+        super(code.getReason().getMessage() + ": " + additionalMessage);
+        this.code = code;
+        this.additionalMessage = additionalMessage;
+    }
+
+    public ErrorReasonDTO getErrorReason() {
+        return this.code.getReason();
+    }
+
+    public ErrorReasonDTO getErrorReasonHttpStatus() {
+        return this.code.getReasonHttpStatus();
+    }
+
+    public ErrorStatus getErrorStatus() {
+        if (this.code instanceof ErrorStatus errorStatus) {
+            return errorStatus;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #6 

## ✅ 작업 내용

- 게시물 업로드 과정에서 게시물 생성 시 제품명, 카테고리id, userId 받고 생성된 postId 돌려주는 로직 작성
- entity에 제목 삭제, 물품명(goods), status 추가
- PostStatus Enum 추가
- dto 폴더 안에 request, response 나눠서 CreatePostRequest/Response 구현 PostService에서 생성 로직 구현 
  - userId는 service에서 UserRepository에서 findId에서 1를 찾도록 고정함
  - converter를 따로 두지 않고 dto안에서 static fromEntity 구현

## 📸 스크린샷
<img width="1557" height="1392" alt="스크린샷 2025-09-29 221404" src="https://github.com/user-attachments/assets/5950add2-c5c9-4d4d-9801-80d57b106380" />


## 📎 기타 참고사항

- ErrorSatus에 USER404, HOBBY404 추가했으나 아직 에러처리를 제대로 구현 못했음 (구현 필요)
  - 에러 처리를 json으로 변환하는 Handler 필요
  - 에러 처리 Handler를 만들면서 에러 처리도 같이 할 생각임..
- 아 그리고 실행하다 보니 이전에 JPA 엔티티 코드 이상한게 있어서 그것도 같이 수정한다고 file changed 가 많아여 (구현한건 post 폴더위주로 보면 됨)
- swagger 명세서 :http://localhost:8080/swagger-ui/index.html
- 아 글고 로그인을 mvp에서 빼는거 어떤지 (스웨거 막혀서 로그인 관련 빌드를 일단 없앴음)