### PR TITLE
[Chore] 예외 처리 전역 핸들러 구현, 스웨거 명세 스키마

### DIFF
--- a/cohobby/build.gradle
+++ b/cohobby/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/hobby/service/HobbyService.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/hobby/service/HobbyService.java
@@ -1,0 +1,28 @@
+package com.backthree.cohobby.domain.hobby.service;
+
+import com.backthree.cohobby.domain.hobby.entity.Hobby;
+import com.backthree.cohobby.domain.hobby.repository.HobbyRepository;
+import com.backthree.cohobby.global.common.response.status.ErrorStatus;
+import com.backthree.cohobby.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class HobbyService {
+    private final HobbyRepository hobbyRepository;
+
+    public Hobby findHobbyById(Long hobbyId) {
+        return hobbyRepository.findById(hobbyId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.HOBBY_NOT_FOUND));
+    }
+
+    public boolean existsById(Long hobbyId) {
+        // Repository의 existsById를 그대로 호출하여 가장 효율적으로 확인합니다.
+        return hobbyRepository.existsById(hobbyId);
+    }
+
+    public Hobby findHobbyReferenceById(Long hobbyId) {
+        return hobbyRepository.getReferenceById(hobbyId);
+    }
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/post/controller/PostController.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/post/controller/PostController.java
@@ -3,8 +3,13 @@ package com.backthree.cohobby.domain.post.controller;
 import com.backthree.cohobby.domain.post.dto.request.CreatePostRequest;
 import com.backthree.cohobby.domain.post.dto.response.CreatePostResponse;
 import com.backthree.cohobby.domain.post.service.PostService;
+import com.backthree.cohobby.global.common.BaseResponse;
+import com.backthree.cohobby.global.common.ErrorResponseDto;
+import com.backthree.cohobby.global.common.response.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -27,16 +32,17 @@ public class PostController {
     @Operation(summary = "게시글 초안 생성", description = "물품 정보 입력을 시작할 때 게시글의 초기 DRAFT 상태를 생성합니다.")
     @ApiResponses({
             @ApiResponse(responseCode="201", description="게시물 생성 성공"),
-            @ApiResponse(responseCode = "400", description = "존재하지 않는 유저/취미 ID")
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저/취미 ID",content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
     })
     @PostMapping()
-    public ResponseEntity<CreatePostResponse> createPost(
+    public ResponseEntity<BaseResponse<CreatePostResponse>> createPost(
             @Valid @RequestBody CreatePostRequest request   // JSON 본문을 받기 위해 @RequestBody 사용, 유효성 검사를 위해 @Valid 추가
     ) {
-        CreatePostResponse response = postService.createPost(request);
-
+        CreatePostResponse payload = postService.createPost(request);
+        BaseResponse<CreatePostResponse> body =
+                BaseResponse.onSuccess(SuccessStatus._CREATED, payload);
         // HTTP 상태 201 Created 와 함께 응답 반환
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ResponseEntity.status(HttpStatus.CREATED).body(body);
     }
 
 

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/post/service/PostService.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/post/service/PostService.java
@@ -1,13 +1,13 @@
 package com.backthree.cohobby.domain.post.service;
 
 import com.backthree.cohobby.domain.hobby.entity.Hobby;
-import com.backthree.cohobby.domain.hobby.repository.HobbyRepository;
 import com.backthree.cohobby.domain.post.dto.request.CreatePostRequest;
 import com.backthree.cohobby.domain.post.dto.response.CreatePostResponse;
 import com.backthree.cohobby.domain.post.entity.Post;
 import com.backthree.cohobby.domain.post.repository.PostRepository;
 import com.backthree.cohobby.domain.user.entity.User;
-import com.backthree.cohobby.domain.user.repository.UserRepository;
+import com.backthree.cohobby.domain.user.service.UserService;
+import com.backthree.cohobby.domain.hobby.service.HobbyService;
 import com.backthree.cohobby.global.exception.GeneralException;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
@@ -20,25 +20,35 @@ import com.backthree.cohobby.global.common.response.status.ErrorStatus;
 public class PostService {
 
     private final PostRepository postRepository;
-    private final UserRepository userRepository;
-    private final HobbyRepository hobbyRepository;
+    private final UserService userService;
+    private final HobbyService hobbyService;
 
     private static final Long DUMMY_USER_ID = 1L;  //임시 유저
 
     @Transactional
     public CreatePostResponse createPost(CreatePostRequest request){
+
+        Long hobbyId = request.getHobbyId();
+
         // ID를 기반으로 각 엔티티가 존재하는지 조회
         // 더미 유저 조회 (없으면 예외)
-        User user = userRepository.findById(DUMMY_USER_ID)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND, "id=" + request.getUserId()));
-        Hobby hobby = hobbyRepository.findById(request.getHobbyId())
-                .orElseThrow(() -> new GeneralException(ErrorStatus.HOBBY_NOT_FOUND,"id=" + request.getHobbyId()));
+        if (!userService.existsById(DUMMY_USER_ID)) {
+            throw new GeneralException(ErrorStatus.USER_NOT_FOUND);
+        }
+        if (!hobbyService.existsById(hobbyId)) {
+            throw new GeneralException(ErrorStatus.HOBBY_NOT_FOUND);
+        }
+
+        // 검증 후, 참조(프록시)만 가져와서 외래키 관계 설정
+
+        User userReference = userService.findUserReferenceById(DUMMY_USER_ID);
+        Hobby hobbyReference = hobbyService.findHobbyReferenceById(hobbyId);
 
         // Post 엔티티 생성
         Post newPost = Post.builder()
                 .goods(request.getGoods())
-                .user(user)
-                .hobby(hobby)
+                .user(userReference)
+                .hobby(hobbyReference)
                 .build();
 
         // 생성된 Post 엔티티를 Repository에 저장

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/user/service/UserService.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/user/service/UserService.java
@@ -1,0 +1,29 @@
+package com.backthree.cohobby.domain.user.service;
+
+import com.backthree.cohobby.domain.user.entity.User;
+import com.backthree.cohobby.domain.user.repository.UserRepository;
+import com.backthree.cohobby.global.common.response.status.ErrorStatus;
+import com.backthree.cohobby.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+    public User findUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+    }
+
+    public boolean existsById(Long userId) {
+        // DB에 가장 가벼운 쿼리를 보내 존재 여부만 확인합니다.
+        return userRepository.existsById(userId);
+    }
+
+
+    //참조(프록시)만 가져오는 함수
+    public User findUserReferenceById(Long userId) {
+        return userRepository.getReferenceById(userId);
+    }
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/global/common/BaseResponse.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/global/common/BaseResponse.java
@@ -7,21 +7,28 @@ import com.backthree.cohobby.global.common.response.status.SuccessStatus;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.Collections;
 
 @Getter
 @AllArgsConstructor(access= AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
 @JsonPropertyOrder({"isSuccess","code","message","result"})
+@Schema(name = "BaseResponse")
 public class BaseResponse<T> {
 
     @JsonProperty("isSuccess")
+    @Schema(description = "성공 여부", example = "true")
     private final Boolean isSuccess;
 
+    @Schema(description = "응답/에러 코드", example = "POST_CREATED")
     private final String code;
+    @Schema(description = "응답 데이터")
     private final String message;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/cohobby/src/main/java/com/backthree/cohobby/global/common/ErrorResponseDto.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/global/common/ErrorResponseDto.java
@@ -1,0 +1,19 @@
+package com.backthree.cohobby.global.common;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(name = "ErrorResponse")
+public class ErrorResponseDto {
+    @JsonProperty("isSuccess")
+    @Schema(description = "성공 여부", example = "false")
+    private boolean isSuccess;
+    @Schema(description = "에러 코드", example = "POST_NOT_FOUND")
+    private String code;
+    @Schema(description = "에러 메시지", example = "게시글을 찾을 수 없습니다.")
+    private String message;
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/global/exception/ExceptionAdvice.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/global/exception/ExceptionAdvice.java
@@ -1,0 +1,58 @@
+package com.backthree.cohobby.global.exception;
+
+import com.backthree.cohobby.global.common.BaseResponse;
+import com.backthree.cohobby.global.common.response.code.ErrorReasonDTO;
+import com.backthree.cohobby.global.common.response.status.ErrorStatus;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+    @ExceptionHandler(value = GeneralException.class)
+    public ResponseEntity<BaseResponse<Object>> handleGeneralException(GeneralException e) {
+        // 1. 발생한 예외에서 에러 코드와 메시지 정보를 가져오기
+        ErrorReasonDTO errorReason = e.getErrorReasonHttpStatus();
+
+        // 2. BaseResponse.onFailure를 사용해 실패 응답을 생성
+        BaseResponse<Object> response = BaseResponse.onFailure(e.getCode().getReason(), null);
+
+        // 3. ResponseEntity에 BaseResponse와 예외에 정의된 HTTP 상태 코드를 담아 반환
+        return ResponseEntity.status(errorReason.getHttpStatus()).body(response);
+    }
+
+    // 잘못된 JSON 요청을 처리하기 위한 메소드 오버라이드
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(
+            HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        BaseResponse<Object> response = BaseResponse.onFailure(ErrorStatus.BAD_REQUEST);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    // 👇 @Valid 유효성 검사 실패 시 처리하기 위한 메소드 오버라이드
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        BaseResponse<Object> response = BaseResponse.onFailure(ErrorStatus.VALIDATION_ERROR);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    // 예상치 못한 모든 예외를 처리
+    @ExceptionHandler(value = Exception.class)
+    public ResponseEntity<BaseResponse<Object>> handleException(Exception e) {
+        // 서버 에러이므로 HTTP 500과 함께 정해진 코드를 반환
+        BaseResponse<Object> response = BaseResponse.onFailure(ErrorStatus.INTERNAL_SERVER_ERROR);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+}


### PR DESCRIPTION

## 📌 관련 이슈

- Closes #8 

## ✅ 작업 내용
- ExceptionAdvice 예외 처리 핸들러 구현
- 에러 스웨거 명세인 ErrorResponseDto 파일 추가
- 기존 BaseResponse 파일에서 스웨거 세팅부분 추가

- 공통 응답 형식을 지키면서 스웨거 명세를 하려면
  - 컨트롤러의 응답을 BaseResponse로 반환하되 제너릭 T를 개별 Response로 두면 됩니다.
  - 예외처리 스웨거 명세는 content를 스키마로 ErrorResponse를 추가하면 됩니다


## 📸 스크린샷
성공 시
<img width="1559" height="1401" alt="스크린샷 2025-09-30 171940" src="https://github.com/user-attachments/assets/e4a4cc0b-05ab-43a9-9cdc-032fe7897803" />

없는 취미 id를 넣을 경우
<img width="1551" height="1388" alt="스크린샷 2025-09-30 171858" src="https://github.com/user-attachments/assets/1f43c4a2-e653-4c48-9873-d7de3bdb96dd" />

스웨거 명세
<img width="1511" height="981" alt="스크린샷 2025-09-30 171913" src="https://github.com/user-attachments/assets/5744c52a-eaf1-4152-ab5a-f34b9000f7de" />

예전에는 일케 됐었음
<img width="1669" height="1002" alt="스크린샷 2025-09-30 105520" src="https://github.com/user-attachments/assets/43928bf4-0406-46ac-a1c2-6fef62730845" />



## 📎 기타 참고사항

- 즉 지금 응답 반환 구조가 
  - 서비스에서 ErrorStatus에서 정의한 예외코드를 던지면
  - 컨트롤러에서 예외를 밖으로 던짐
  - @RestControllerAdvice가 예외를 가로챔 (@RestControllerAdvice가 붙은 클래스에 정의된 @ExceptionHandler가 해당 예외를 잡아서 처리)
  - 일관된 에러 응답 반환: @ExceptionHandler 메소드는 지정된 형식(예:JSON)으로 에러 응답 (BaseResponse)을 생성하여 클라이언트에게 반환

- 스웨거 명세는
  - BaseResponse에 @Schema로 springdoc가 읽도록 함
  - 컨트롤러에서 BaseReponse를 반환하되 개별 Response를 제너릭으로 두어서 상세하게 springdoc가 상세하게 읽을 수 있음
  - 예외 처리를 ErrorResponseDto로  따로 명세 (근데 합칠 수 있을 것 같은데 아직 예외 처리 스웨거 명세 원리는 이해를 다 못했음..)


이렇게 설계했는데 궁금한 점이나 더 좋은 의견 있으면 말해주세요!!