### PR TITLE
feat: pg 결제 생성, 승인  api 구현

### DIFF
--- a/cohobby/src/main/java/com/backthree/cohobby/domain/payment/controller/PaymentController.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/payment/controller/PaymentController.java
@@ -1,0 +1,81 @@
+package com.backthree.cohobby.domain.payment.controller;
+
+import com.backthree.cohobby.domain.payment.dto.request.PaymentConfirmRequest;
+import com.backthree.cohobby.domain.payment.dto.request.PaymentIntentRequest;
+import com.backthree.cohobby.domain.payment.dto.request.TossWebhookRequest;
+import com.backthree.cohobby.domain.payment.dto.response.PaymentDetailResponse;
+import com.backthree.cohobby.domain.payment.dto.response.PaymentIntentResponse;
+import com.backthree.cohobby.domain.payment.dto.response.PaymentConfirmResponse;
+import com.backthree.cohobby.domain.payment.service.PaymentService;
+import com.backthree.cohobby.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/payments")
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentController {
+    private final PaymentService paymentService;
+
+    //결제 의도 생성
+    @PostMapping("/intents")
+    public ResponseEntity<PaymentIntentResponse> createPaymentIntent(
+            @RequestBody PaymentIntentRequest request,
+            User user //수정사항: 사용자 인증 로직 필요
+    ){
+        PaymentIntentResponse response = paymentService.createPaymentIntent(request, user);
+        return ResponseEntity.ok(response);
+    }
+
+    //결제 승인
+    @PostMapping("/confirm")
+    public ResponseEntity<PaymentConfirmResponse> confirmPayment(
+            @RequestBody PaymentConfirmRequest request
+            ){
+        PaymentConfirmResponse response = paymentService.confirmPayment(request);
+        return ResponseEntity.ok(response);
+    }
+
+    //웹훅 수신
+    @PostMapping("/webhook")
+    public ResponseEntity<String> handleWebhook(
+            @RequestBody TossWebhookRequest request,
+            @RequestHeader("Toss-Signature") String signatureHeader){
+        //1. 보안 검증
+        /* sdk 연결 후에 시그니처 검증까지 실행하도록 주석 해제
+        if(!paymentService.isValidSignature(request, signatureHeader)){
+            log.warn("Webhook signature 검증 실패: {}", request);
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid signature");
+        }
+        */
+
+        //2. 서비스 로직으로 웹훅 처리
+        try{
+            paymentService.handleWebhook(request);
+            return ResponseEntity.ok("Webhook 생성");
+        }catch(Exception e){
+            log.error("Webhook 처리 실패", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Error");
+        }
+
+
+    }
+
+    //개별 결제 조회
+    @GetMapping("/{paymentId}")
+    public ResponseEntity PaymentDetailResponse(
+            @PathVariable Long paymentId,
+            @RequestBody User user //사용자 검증 로직
+    ){
+        //1. 유저 검증
+
+        //2. 결제 정보 빈환
+        PaymentDetailResponse response = paymentService.getPaymentDetail(paymentId, user);
+        return ResponseEntity.ok(response);
+
+    }
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/payment/dto/request/PaymentConfirmRequest.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/payment/dto/request/PaymentConfirmRequest.java
@@ -1,0 +1,8 @@
+package com.backthree.cohobby.domain.payment.dto.request;
+
+public record PaymentConfirmRequest (
+        String orderId, //시스템에서 발급한 주문 번호, pgOrderNo에 대응됨
+        String paymentKey, //PG사가 발급한 결제 키
+        Integer amount //최종 결제 금액(검증용)
+) {
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/payment/dto/request/PaymentIntentRequest.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/payment/dto/request/PaymentIntentRequest.java
@@ -1,0 +1,9 @@
+package com.backthree.cohobby.domain.payment.dto.request;
+
+import com.backthree.cohobby.domain.payment.entity.PaymentMethod;
+
+public record PaymentIntentRequest(
+        Long rentId, //대여 건 구별
+        Integer amount //결제 요청 금액
+) {
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/payment/dto/request/TossWebhookRequest.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/payment/dto/request/TossWebhookRequest.java
@@ -1,0 +1,16 @@
+package com.backthree.cohobby.domain.payment.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TossWebhookRequest {
+    private String eventType; //PAYMENT_APPROVED, PAYMENT_CANCELED 등
+    private String paymentKey; //토스에서 발급하는 결제 키
+    private String orderId; //pgOrderNo
+    private String status;
+    private String approvedAt;
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/payment/dto/response/PaymentConfirmResponse.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/payment/dto/response/PaymentConfirmResponse.java
@@ -1,0 +1,26 @@
+package com.backthree.cohobby.domain.payment.dto.response;
+
+import com.backthree.cohobby.domain.payment.entity.Payment;
+import com.backthree.cohobby.domain.payment.entity.PaymentStatus;
+
+import java.time.LocalDateTime;
+
+public record PaymentConfirmResponse(
+        Long paymentId,
+        String pgOrderNo,
+        Integer amountCaptured,
+        PaymentStatus status,
+        LocalDateTime capturedAt,
+        LocalDateTime authorizedAt
+) {
+    public static PaymentConfirmResponse from(Payment payment){
+        return new PaymentConfirmResponse(
+                payment.getId(),
+                payment.getPgOrderNo(),
+                payment.getAmountCaptured(),
+                payment.getStatus(),
+                payment.getCapturedAt(),
+                payment.getAuthorizedAt()
+        );
+    }
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/payment/dto/response/PaymentDetailResponse.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/payment/dto/response/PaymentDetailResponse.java
@@ -1,0 +1,32 @@
+package com.backthree.cohobby.domain.payment.dto.response;
+
+import com.backthree.cohobby.domain.payment.entity.Payment;
+import com.backthree.cohobby.domain.payment.entity.PaymentMethod;
+import com.backthree.cohobby.domain.user.entity.User;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record PaymentDetailResponse (
+    Long paymentId,
+    PaymentMethod paymentMethod,
+    Integer amountCaptured,
+    LocalDateTime capturedAt,
+    Long rentId,
+    String orderName,
+    String customerName
+)
+{
+    public static PaymentDetailResponse from(Payment payment, User user) {
+        return new PaymentDetailResponse(
+                payment.getId(),
+                payment.getMethod(),
+                payment.getAmountCaptured(),
+                payment.getCapturedAt(),
+                payment.getRent().getId(),
+                payment.getOrderName(),
+                user.getNickname()
+        );
+    }
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/payment/dto/response/PaymentIntentResponse.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/payment/dto/response/PaymentIntentResponse.java
@@ -1,0 +1,35 @@
+package com.backthree.cohobby.domain.payment.dto.response;
+
+import com.backthree.cohobby.domain.payment.entity.Payment;
+import com.backthree.cohobby.domain.payment.entity.PaymentMethod;
+import com.backthree.cohobby.domain.user.entity.User;
+import com.backthree.cohobby.global.config.payments.PaymentsConfig;
+import lombok.Builder;
+
+@Builder
+public record PaymentIntentResponse (
+        PaymentMethod method,
+        Integer amountValue, //결제 금액
+        String amountCurrency, //결제 통화 - KRW만 지원
+        String orderName, //구매상품
+        String pgOrderNo, //주문번호
+        String customerName,
+        String customerEmail,
+        String successUrl,
+        String failUrl
+        )
+{
+    public static PaymentIntentResponse from(Payment payment, User user, PaymentsConfig urlConfig) {
+        return PaymentIntentResponse.builder()
+                .method(payment.getMethod())
+                .amountValue(payment.getAmountExpected())
+                .amountCurrency(payment.getCurrency())
+                .orderName(payment.getOrderName())
+                .pgOrderNo(payment.getPgOrderNo())
+                .customerName(user.getNickname())
+                .customerEmail(user.getEmail())
+                .successUrl(urlConfig.getSuccessUrl())
+                .failUrl(urlConfig.getFailUrl())
+                .build();
+    }
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/payment/entity/Payment.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/payment/entity/Payment.java
@@ -49,6 +49,38 @@ public class Payment extends BaseTimeEntity {
     @JoinColumn(name = "rentId", nullable = false)
     private Rent rent;
 
+    @Setter
+    private String orderName; //결제의도 생성 api 응답 위해 추가
+
     @OneToMany(mappedBy = "payment")
     private List<Refund> refunds = new ArrayList<>();
+
+    // payment-refund 양방향 정의를 위해 추가
+    public void addRefund(Refund refund) {
+        this.refunds.add(refund);
+    }
+
+    // 결제 승인 완료 처리
+    public void confirmSuccess(String pgPaymentKey, LocalDateTime capturedAt, String provider) {
+        this.status = PaymentStatus.CAPTURED;
+        this.pgPaymentKey = pgPaymentKey;
+        this.amountCaptured = this.amountExpected;
+        this.capturedAt = capturedAt;
+        this.authorizedAt = capturedAt;
+        this.provider = provider;
+        this.failureCode = null;
+        this.failureMessage = null;
+    }
+
+    // 결제 실패 처리
+    public void confirmFailure(String failureCode, String failureMessage) {
+        this.status = PaymentStatus.FAILED;
+        this.failureCode = failureCode;
+        this.failureMessage = failureMessage;
+    }
+
+    // 환불로 상태 변경
+    public void toRefunded(){
+        this.status = PaymentStatus.REFUNDED;
+    }
 }

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/payment/entity/PaymentMethod.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/payment/entity/PaymentMethod.java
@@ -7,12 +7,13 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum PaymentMethod {
     CARD("CARD"),
-    ACCOUNT("ACCOUNT"),
+    EASY_PAY("EASY_PAY"),
     VIRTUAL_ACCOUNT("VIRTUAL_ACCOUNT"),
+    MOBILE_PHONE("MOBILE_PHONE"),
     TRANSFER("TRANSFER"),
-    MOBILE("MOBILE"),
-    POINT("POINT"),
-    ETC("ETC");
+    CULTURE_GIFT_CERTIFICATE("CULTURE_GIFT_CERTIFICATE"),
+    BOOK_GIFT_CERTIFICATE("BOOK_GIFT_CERTIFICATE"),
+    GAME_GIFT_CERTIFICATE("GAME_GIFT_CERTIFICATE");
 
     private final String value;
 }

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/payment/repository/PaymentRepository.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/payment/repository/PaymentRepository.java
@@ -3,5 +3,8 @@ package com.backthree.cohobby.domain.payment.repository;
 import com.backthree.cohobby.domain.payment.entity.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    Optional<Payment> findByPgOrderNo(String pgOrderNo);
 }

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/payment/service/PaymentService.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/payment/service/PaymentService.java
@@ -1,0 +1,191 @@
+package com.backthree.cohobby.domain.payment.service;
+
+import com.backthree.cohobby.domain.payment.dto.request.PaymentConfirmRequest;
+import com.backthree.cohobby.domain.payment.dto.request.PaymentIntentRequest;
+import com.backthree.cohobby.domain.payment.dto.request.TossWebhookRequest;
+import com.backthree.cohobby.domain.payment.dto.response.PaymentDetailResponse;
+import com.backthree.cohobby.domain.payment.dto.response.PaymentIntentResponse;
+import com.backthree.cohobby.domain.payment.dto.response.PaymentConfirmResponse;
+import com.backthree.cohobby.domain.payment.entity.Payment;
+import com.backthree.cohobby.domain.payment.entity.PaymentMethod;
+import com.backthree.cohobby.domain.payment.entity.PaymentStatus;
+import com.backthree.cohobby.domain.payment.repository.PaymentRepository;
+import com.backthree.cohobby.domain.rent.entity.Rent;
+import com.backthree.cohobby.domain.rent.repository.RentRepository;
+import com.backthree.cohobby.domain.user.entity.User;
+import com.backthree.cohobby.global.config.payments.PaymentsConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class PaymentService {
+    private final PaymentRepository paymentRepository;
+    private final RentRepository rentRepository;
+    private final PaymentsConfig paymentsConfig;
+
+    // 결제 의도 생성(DB에 PENDING 상태로 저장
+    public PaymentIntentResponse createPaymentIntent(PaymentIntentRequest request, User user) {
+        //Rent 정보 조회
+        Rent rent = rentRepository.findById(request.rentId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 대여입니다."));
+        if(!rent.getTotalPrice().equals(request.amount())){ //Rent 대여 금액과 결제 금액 비교
+            throw new IllegalArgumentException("결제 요청 금액이 대여 금액과 일치하지 않습니다.");
+        }
+
+        //구매상품 가져오기
+        String orderName = rent.getPost().getGoods();
+        //주문번호 생성 - 랜덤으로
+        String pgOrderNo = "cohobby-"+ UUID.randomUUID().toString();
+
+        Payment payment = Payment.builder()
+                .rent(rent)
+                .method(PaymentMethod.TRANSFER) //계좌이체를 디폴트로 설정
+                .amountExpected(request.amount())
+                .currency("KRW") //KRW를 디폴트로 설정
+                .orderName(orderName)
+                .pgOrderNo(pgOrderNo)
+                .status(PaymentStatus.PENDING)
+                .createdAt(LocalDateTime.now())
+                .build();
+        paymentRepository.save(payment);
+
+        return PaymentIntentResponse.from(payment, user, paymentsConfig);
+    }
+
+    //결제 승인
+    public PaymentConfirmResponse confirmPayment(PaymentConfirmRequest request) {
+        //주문번호로 payment 조회
+        Payment payment = paymentRepository.findByPgOrderNo(request.orderId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 주문입니다."));
+
+        //금액 위변조 검증
+        if(!payment.getAmountExpected().equals(request.amount())){
+            throw new IllegalArgumentException("결제 금액이 요청 금액과 일치하지 않습니다.");
+        }
+
+        //PG사 결제 승인 API 호출
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = createAuthHeaders();
+
+        //PG사에 보낼 요청 본문 생성
+        Map<String, Object> body = Map.of(
+                "paymentKey", request.paymentKey(),
+                "orderId", request.orderId(),
+                "amount", request.amount()
+        );
+
+        try{
+            //PG사에 승인 요청 보내기(pg사의 결제승인 api 호출)
+            /*  프론트 구현으로 sdk 연결 이후에 실제 테스트 가능
+            String pgResponse = restTemplate.postForObject(
+                    paymentsConfig.getToss().getConfirmUrl(),
+                    new HttpEntity<>(body, headers),
+                    String.class
+            );
+            */
+            String pgResponse = "{ \"status\": \"DONE\", \"approvedAt\": \"2025-10-07T10:00:00\" }";
+
+
+            //성공 시 Payment 상태 업데이트
+            log.info("PG사 승인 응답: {}", pgResponse);
+            payment.confirmSuccess(request.paymentKey(), LocalDateTime.now(), "TOSS");
+
+        }catch(Exception e){
+            //실패 시 Payment 상태 업데이트 + 예외 처리
+            log.error("PG사 결제 승인 실패: {}", e.getMessage());
+            payment.confirmFailure("PG_ERROR", e.getMessage());
+            throw new RuntimeException("결제 승인에 실패했습니다");
+        }
+
+        //save는 @Transactional에 의해 자동 처리됨
+        return PaymentConfirmResponse.from(payment);
+    }
+
+    private HttpHeaders createAuthHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        //secret key를 basic auth로 설정
+        //spring이 내부적으로 Base64 인코딩 수행해줌
+        headers.setBasicAuth(paymentsConfig.getToss().getSecretKey(), "");
+        //요청/응답 타입 JSON
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+        return headers;
+    }
+
+    //Signature 검증
+    public boolean isValidSignature(Object requestBody, String signatureHeader) {
+        try{
+            String secretkey = paymentsConfig.getToss().getSecretKey();
+
+            //body를 JSON 문자열로 변환
+            ObjectMapper mapper = new ObjectMapper();
+            String bodyJson = mapper.writeValueAsString(requestBody);
+
+            Mac sha256HMAC = Mac.getInstance("HmacSHA256");
+            SecretKeySpec secretKey = new SecretKeySpec(secretkey.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+            sha256HMAC.init(secretKey);
+
+            byte[] hash = sha256HMAC.doFinal(bodyJson.getBytes(StandardCharsets.UTF_8));
+            String computedSignature = Base64.getEncoder().encodeToString(hash);
+
+            return computedSignature.equals(signatureHeader);
+        } catch (Exception e) {
+            log.error("Webhook Signature 검증 실패", e);
+            return false;
+        }
+    }
+
+    //웹훅 처리 로직
+    public void handleWebhook(TossWebhookRequest request) {
+        //orderNo로 payment 존재하는지 검증
+        Payment payment = paymentRepository.findByPgOrderNo(request.getOrderId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 주문: " + request.getOrderId()));
+
+        //이미 승인된 payment라면 토스에서 보내주는 paymentKey와 db의 paymentKey가 일치하는지 비교)
+        if (payment.getPgPaymentKey() != null
+                && !payment.getPgPaymentKey().equals(request.getPaymentKey())) {
+            throw new IllegalStateException("PaymentKey 불일치: 요청된 key="
+                    + request.getPaymentKey()
+                    + ", 저장된 key="
+                    + payment.getPgPaymentKey());
+        }
+
+        switch(request.getStatus().toUpperCase()){
+            case "DONE" -> payment.confirmSuccess(request.getPaymentKey(), LocalDateTime.now(), "TOSS_WEBHOOK");
+            case "CANCELLED" -> payment.confirmFailure("TOSS_CANCELLED", "토스에서 결제 취소됨");
+            case "FAILED" -> payment.confirmFailure("TOSS_FAILED", "토스에서 결제 실패");
+            default -> log.warn("결제 도중 예외 상태 전달: {}", request.getStatus());
+        }
+
+        log.info("Webhook 처리 완료: orderId = {}, status = {}", request.getOrderId(), request.getStatus());
+    }
+
+    //개별 결제 조회
+    @Transactional(readOnly = true)
+    public PaymentDetailResponse getPaymentDetail(Long paymentId, User user) {
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 결제 정보를 찾을 수 없습니다: " + paymentId));
+
+        return PaymentDetailResponse.from(payment, user);
+    }
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/global/config/payments/PaymentsConfig.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/global/config/payments/PaymentsConfig.java
@@ -1,0 +1,24 @@
+package com.backthree.cohobby.global.config.payments;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "payment")
+public class PaymentsConfig {
+    private Toss toss = new Toss();
+    private String successUrl;
+    private String failUrl;
+
+    @Getter
+    @Setter
+    public static class Toss {
+        private String secretKey;
+        private String securityKey;
+        private String confirmUrl;
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #15 

## ✅ 작업 내용

- 작업한 주요 내용을 bullet point로 정리해주세요.
- 토스 페이먼츠 api 사용하여 pg 결제 백엔드 로직 작성
- 결제 의도 생성
  - 대여 정보, 금액 일치 확인 후 랜덤 주문번호 생성
  - 결제방식, 주문번호 등의 결제정보를 담아 프론트에 전달
- 결제 승인
  - sdk에서 완료된 결과를 받아 해당 결제 내용을 검증하고 토스의 결제승인 api 호출
- 웹훅 수신
  - 결제 완료되었지만 아직 상태가 업데이트되지 않은 결제의 상태를 업데이트
- 개별 결제 조회

## 📸 스크린샷

<br>[결제 의도 생성]
<img width="2000" height="889" alt="image" src="https://github.com/user-attachments/assets/929060db-8dca-4faf-9380-02f85a10e5d8" />
<img width="1770" height="577" alt="image" src="https://github.com/user-attachments/assets/6d507994-1772-4f45-91c2-e862f9e1839a" />
-새로운 결제정보 생성


<br>[결제 승인]
<img width="2000" height="855" alt="image" src="https://github.com/user-attachments/assets/3c9fee75-7cdf-4d2e-8986-7d638973b816" />
<img width="1882" height="597" alt="image" src="https://github.com/user-attachments/assets/8c5a3814-5e75-4b50-85b9-42af87459517" />
-마지막 결제정보 업데이트

<br>[웹훅 수신]
<img width="2000" height="791" alt="image" src="https://github.com/user-attachments/assets/3658f4ea-ec6b-4469-8c74-cdf14d56ba0f" />
<img width="2000" height="789" alt="image" src="https://github.com/user-attachments/assets/22110543-72af-4472-aa0a-4dabfaddd6a8" />
-아직 배포 url이 확정되지 않아서 ngrok을 사용하여 임시로 포워딩한 주소로 api 요청을 보내야 함
<img width="1196" height="341" alt="image" src="https://github.com/user-attachments/assets/02e5c5e8-fac4-43ab-a5f9-008abf15010a" />
-업데이트 되지 않은 결제 정보 업데이트

<br>[개별 결제 조회]
<img width="2000" height="981" alt="image" src="https://github.com/user-attachments/assets/14ac7d7e-1b19-4e23-a64d-db449e5524d0" />


## 📎 기타 참고사항

- 프론트에서 sdk 구현이 완료되어야(+웹훅은 서비스 url이 있어야 결제 후 자동으로 수신 가능함) 실제 토스 api에 연결할 수 있어서 지금은 백엔드 로직만 테스트하도록 뒀습니다
- 유저 조회&검증하는 로직은 oauth 인증 api 구현한 후 추가하겠습니다
- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.