### PR TITLE
feat: 카카오 oauth 로그인 추가

### DIFF
--- a/cohobby/build.gradle
+++ b/cohobby/build.gradle
@@ -35,6 +35,11 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/user/controller/AuthController.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/user/controller/AuthController.java
@@ -1,0 +1,66 @@
+package com.backthree.cohobby.domain.user.controller;
+
+import com.backthree.cohobby.domain.user.dto.TokenDTO;
+import com.backthree.cohobby.domain.user.dto.TokenRefreshRequestDTO;
+import com.backthree.cohobby.domain.user.entity.User;
+import com.backthree.cohobby.domain.user.repository.RefreshTokenRepository;
+import com.backthree.cohobby.domain.user.repository.UserRepository;
+import com.backthree.cohobby.global.config.security.JwtService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final JwtService jwtService;
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    /*@PostMapping("/signup-extra")
+    public ResponseEntity<String> handleForm(@RequestBody SignupExtraDTO dto,
+                             @AuthenticationPrincipal User user) {
+        user.updateAdditionalInfo(
+                Gender.valueOf(dto.getGender()),
+                dto.getBirthYear(),
+                dto.getBirthday(),
+                dto.getPhoneNumber());
+        userRepository.save(user);
+        return ResponseEntity.ok("사용자 추가 정보가 성공적으로 업데이트되었습니다.");
+    }*/
+
+    @PostMapping("/logout")
+    public ResponseEntity<String> logout(@AuthenticationPrincipal User user) throws IOException {
+        refreshTokenRepository.findByUser(user)
+                        .ifPresent(refreshTokenRepository::delete);
+        return ResponseEntity.ok("로그아웃되었습니다.");
+    }
+
+    @PostMapping("/token/refresh")
+    public ResponseEntity<TokenDTO> refreshToken(@RequestBody TokenRefreshRequestDTO requestDTO) throws IOException {
+        String refreshToken = requestDTO.getRefreshToken();
+        //리프레시 토큰 유효성 검증
+        if(refreshToken == null || !jwtService.validateToken(refreshToken)) {
+            throw new IllegalArgumentException("유효하지 않은 리프레시 토큰입니다.");
+        }
+        //DB에 저장한 리프레시 토큰과 일치하는지 검증
+        refreshTokenRepository.findByToken(refreshToken)
+                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않거나 폐기된 리프레시 토큰입니다."));
+        //새로운 액세스 토큰 발급
+        String email = jwtService.extractEmail(refreshToken);
+        String newAccessToken = jwtService.createAccessToken(email);
+        return ResponseEntity.ok(TokenDTO.builder().accessToken(newAccessToken).build());
+    }
+
+    @PostMapping("/kakao/unlink")
+    public ResponseEntity<String> unlink(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/user/dto/KakaoAccountDTO.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/user/dto/KakaoAccountDTO.java
@@ -1,0 +1,29 @@
+package com.backthree.cohobby.domain.user.dto;
+
+import com.backthree.cohobby.domain.user.entity.Gender;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true) //dto에 정의되지 않은 항목은 무시하도록 설정
+public class KakaoAccountDTO {
+    @JsonProperty("email")
+    private String email;
+
+    @JsonProperty("birthyear")
+    private String birthYear;
+
+    @JsonProperty("birthday")
+    private String birthday;
+
+    @JsonProperty("gender")
+    private Gender gender;
+
+    @JsonProperty("phone_number")
+    private String phoneNumber;
+
+    @JsonProperty("profile")
+    private KakaoProfileDTO profile;
+
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/user/dto/KakaoProfileDTO.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/user/dto/KakaoProfileDTO.java
@@ -1,0 +1,30 @@
+package com.backthree.cohobby.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoProfileDTO {
+    //이메일은 바로 가져옴
+    @JsonProperty("email")
+    private String email;
+
+    //nickname, profileImage는 profile 객체 안에 중첩되어있어서 따로 꺼내줘야 함
+    private String nickname;
+    private String profileImageUrl;
+
+    //Jackson이 JSON의 'profile' 키를 발견하면 이 메소드를 호출
+    // profile 객체(Map) 내부에서 닉네임&이미지 추출하여 DTO 필드에 직접 할당
+    @SuppressWarnings("unchecked")
+    @JsonProperty("profile")
+    private void unpackNestedProfile(Map<String, Object> profile){
+        if(profile != null){
+            this.nickname = (String)profile.get("nickname");
+            this.profileImageUrl = (String)profile.get("profile_image_url");
+        }
+    }
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/user/dto/KakaoUserInfo.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/user/dto/KakaoUserInfo.java
@@ -1,0 +1,54 @@
+package com.backthree.cohobby.domain.user.dto;
+
+import com.backthree.cohobby.domain.user.entity.Gender;
+import com.backthree.cohobby.domain.user.entity.User;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.Map;
+
+@Getter
+public class KakaoUserInfo {
+    private final String providerId; //카카오 provider 아이디
+    private final KakaoProfileDTO profileDTO;
+
+    public KakaoUserInfo(Map<String, Object> attributes) {
+        this.providerId = String.valueOf(attributes.get("id"));
+        ObjectMapper mapper = new ObjectMapper();
+        this.profileDTO = mapper.convertValue(attributes.get("kakao_account"), KakaoProfileDTO.class);
+    }
+
+    public User toEntity(){
+        String email = profileDTO.getEmail();
+        String nickname = profileDTO.getNickname();
+        String profileImage = profileDTO.getProfileImageUrl();
+
+        /* Kakao account dto 사용할 때 검사할 내용
+        //형변환
+        //birthyear 들어왔으면 integer로 변환
+        Integer birthYear = birthYearStr != null ? Integer.valueOf(birthYearStr) : null;
+        //birthday 들어왔으면 localdate로 변환
+        LocalDate birthday = null;
+        // birthyear와 birthday가 모두 존재하고, birthday가 4자리(MMdd)일 때만 파싱 시도
+        if (birthYearStr != null && !birthYearStr.isEmpty() && birthdayStr != null && birthdayStr.length() == 4) {
+            try {
+                // ex. "2003" + "-" + "01" + "-" + "30" -> "2003-01-30"
+                String fullBirthDate = birthYearStr + "-" + birthdayStr.substring(0, 2) + "-" + birthdayStr.substring(2, 4);
+                birthday = LocalDate.parse(fullBirthDate);
+            } catch (DateTimeParseException e) {
+                System.err.println("KakaoUserInfo: 생일 파싱 실패. " + e.getMessage());
+                // 파싱 실패 시 null 유지
+            }
+        }*/
+        return User.builder()
+                .email(email)
+                .nickname(nickname)
+                .profilePicture(profileImage)
+                .providerId(this.providerId)
+                .score(0)
+                .isBanned(false)
+                .build();
+    }
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/user/dto/TokenDTO.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/user/dto/TokenDTO.java
@@ -1,0 +1,16 @@
+package com.backthree.cohobby.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class TokenDTO {
+    private final String accessToken;
+    private final String refreshToken;
+
+    @Builder
+    public TokenDTO(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/user/dto/TokenRefreshRequestDTO.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/user/dto/TokenRefreshRequestDTO.java
@@ -1,0 +1,10 @@
+package com.backthree.cohobby.domain.user.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TokenRefreshRequestDTO {
+    private String refreshToken;
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/user/entity/Gender.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/user/entity/Gender.java
@@ -1,5 +1,6 @@
 package com.backthree.cohobby.domain.user.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -10,4 +11,9 @@ public enum Gender {
     FEMALE("FEMALE");
 
     private final String value;
+    @JsonCreator
+    public static Gender from(String s) {
+        // 문자열을 대문자로 바꾸고 일치하는 Enum 값을 찾아 반환
+        return Gender.valueOf(s.toUpperCase());
+    }
 }

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/user/entity/RefreshToken.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/user/entity/RefreshToken.java
@@ -1,0 +1,33 @@
+package com.backthree.cohobby.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id",  nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String token;
+
+    @Builder
+    public RefreshToken(User user, String token) {
+        this.user = user;
+        this.token = token;
+    }
+
+    public void updateToken(String newToken) {
+        this.token = newToken;
+    }
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/user/entity/User.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/user/entity/User.java
@@ -4,9 +4,13 @@ import com.backthree.cohobby.domain.common.BaseTimeEntity;
 import com.backthree.cohobby.domain.rent.entity.Rent;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 @Entity
@@ -14,15 +18,15 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class User extends BaseTimeEntity {
+public class User extends BaseTimeEntity implements UserDetails {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 63)
+    @Column(nullable = true, length = 63)
     private String nickname;
 
-    @Column(nullable = false, length = 127)
+    @Column(nullable = true, length = 127)
     private String email;
 
     @Column(length = 127)
@@ -34,21 +38,79 @@ public class User extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Gender gender;
 
-    @Column(nullable = false)
+    //@Column(nullable = false)
     private Integer birthYear;
 
-    @Column(nullable = false)
-    private LocalDateTime birthday;
+    //@Column(nullable = false)
+    private LocalDate birthday;
 
     @Column(nullable = false)
     private Boolean isBanned;
 
-    @Column(nullable = false, length = 31)
+    //@Column(nullable = false, length = 31)
     private String phoneNumber;
+
+    //카카오 고유 ID 저장 필드, 카카오 연결 끊기를 위해 필요
+    @Column(nullable = false, unique = true)
+    private String providerId;
 
     @OneToMany(mappedBy = "owner")
     private List<Rent> rentsOwned = new ArrayList<>();
 
     @OneToMany(mappedBy = "borrower")
     private List<Rent> rentsBorrowed = new ArrayList<>();
+
+    public void updateAdditionalInfo(Gender gender, Integer birthYear, LocalDate birthday, String phoneNumber) {
+        this.gender = gender;
+        this.birthYear = birthYear;
+        this.birthday = birthday;
+        this.phoneNumber = phoneNumber;
+    }
+
+    //userdetails 인터페이스 구현 메소드 오버라이드
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        //모든 사용자를 "role_user" 권한으로 통일
+        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public String getPassword() {
+        //OAuth2를 사용하므로 비번을 따로 필요 X
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return this.email; //이메일을 식별자로 사용
+    }
+
+    //계정 만료
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    //계정 잠겼는지
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    //자격증명(비번) 만료되었는지
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    //계정 활성화 여부 - isBanned 필드 사용
+    @Override
+    public boolean isEnabled() {
+        return !this.isBanned;
+    }
+
+    //계정 비활성화
+    public void withdraw(){
+        this.isBanned = true;
+    }
 }

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/user/repository/RefreshTokenRepository.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/user/repository/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package com.backthree.cohobby.domain.user.repository;
+
+import com.backthree.cohobby.domain.user.entity.RefreshToken;
+import com.backthree.cohobby.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByUser(User user);
+    Optional<RefreshToken> findByToken(String token);
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/user/repository/UserRepository.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/user/repository/UserRepository.java
@@ -3,5 +3,10 @@ package com.backthree.cohobby.domain.user.repository;
 import com.backthree.cohobby.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+    //이미 가입된 사용자인지 이메일로 판단
+    Optional<User> findByEmail(String email);
+    Optional<User> findByProviderId(String providerId);
 }

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/user/service/CustomOAuth2UserService.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/user/service/CustomOAuth2UserService.java
@@ -1,0 +1,69 @@
+package com.backthree.cohobby.domain.user.service;
+
+import com.backthree.cohobby.domain.user.dto.KakaoUserInfo;
+import com.backthree.cohobby.domain.user.entity.User;
+import com.backthree.cohobby.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest){
+        //카카오 인증된 유저 가져오기
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        var attributes = oAuth2User.getAttributes();
+// [ ‼️ 디버그 코드 추가 ‼️ ]
+        System.out.println("==========================================");
+        System.out.println("### KAKAO ATTRIBUTES ###: " + attributes);
+        System.out.println("==========================================");
+        //우리 서비스에 등록되어있는 유저인지 이메일로 검증
+        KakaoUserInfo userInfo = new KakaoUserInfo(attributes);
+        String email = userInfo.getProfileDTO().getEmail(); //이메일로 기존 회원 조회
+        String providerId = userInfo.getProviderId(); //providerId는 신규 가입 시에만 사용
+        if (email == null) {
+            throw new OAuth2AuthenticationException("카카오로부터 계정의 이메일 주소를 받지 못했습니다.");
+        }
+        //등록 안되어있는 유저이면 db에 새로 저장
+        User user = userRepository.findByEmail(email)
+                .orElseGet(() -> {
+                    User newUser = User.builder()
+                                    .providerId(providerId)
+                                    .nickname(userInfo.getProfileDTO().getNickname())
+                                    .email(email)
+                                    .profilePicture(userInfo.getProfileDTO().getProfileImageUrl())
+                                    .score(0)
+                                    .isBanned(false)
+                                    .build();
+                    return userRepository.save(newUser);
+                });
+
+        // 5. 'authentication.getName()'이 email를 반환하도록 속성 맵을 설정
+        //Spring security가 email 속성을 찾을 수 있또록 attributes에 추가
+        Map<String, Object> customAttributes = new HashMap<>(attributes);
+        customAttributes.put("email", email);
+
+        // 6. oAuth2User 원본 대신, 우리 'User' 정보가 담긴 새 'DefaultOAuth2User'를 반환
+        return new DefaultOAuth2User(
+                user.getAuthorities(), // User 엔티티에 정의된 getAuthorities() 호출 (ROLE_USER 반환)
+                customAttributes,      // 'email' 키가 추가된 속성 맵
+                "email"
+        );
+    }
+
+
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/user/service/CustomUserDetailsService.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/user/service/CustomUserDetailsService.java
@@ -1,0 +1,21 @@
+package com.backthree.cohobby.domain.user.service;
+
+import com.backthree.cohobby.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException{
+        //여기서 username: 식별자인 email
+        return userRepository.findByEmail(username)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 이메일을 가진 사용자를 찾을 수 없습니다: " + username));
+    }
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/global/config/security/JwtAuthenticationFilter.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/global/config/security/JwtAuthenticationFilter.java
@@ -1,0 +1,61 @@
+package com.backthree.cohobby.global.config.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtService jwtService;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+            ) throws ServletException, IOException {
+
+        //1. 헤더에서 Authorization 값을 찾는다
+        final String authorizationHeader = request.getHeader("Authorization");
+        final String jwtToken;
+        final String email;
+        //2. 헤더가 없거나 Bearer로 시작하지 않으면 요청을 통과시킴(로그인 안 한 사용자라는 뜻)
+        if(authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        //3. Bearer 부분을 잘라내고 순수 토큰(jwt)만 추출
+        jwtToken = authorizationHeader.substring(7);
+        //4. 토큰에서 이메일 추출
+        email = jwtService.extractEmail(jwtToken);
+        //5. 이메일이 있고 아직 인증 정보가 없는 사용자인지 검증
+        if(email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            //6. db에서 사용자 정보 가져옴(db 조회가 1번만 이루어지도록 UserDetails로 가져오기)
+            UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+            //7. 토큰이 유효하고 db에도 사용자가 있으면 공식 인증서(Authentication)을 만듦
+            if(jwtService.validateToken(jwtToken) && userDetails.isEnabled()) {
+                Authentication authentication = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities()); //userdetails에서 직접 권한 목록을 가져옴
+                //8. Spring security의 보안 컨텍스트에 이 인증서를 등록
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+
+        //9. 필터로 요청/응답을 넘김
+        filterChain.doFilter(request, response);
+    }
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/global/config/security/JwtService.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/global/config/security/JwtService.java
@@ -1,0 +1,133 @@
+package com.backthree.cohobby.global.config.security;
+
+import com.backthree.cohobby.domain.user.dto.TokenDTO;
+import com.backthree.cohobby.domain.user.entity.User;
+import com.backthree.cohobby.domain.user.repository.RefreshTokenRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Service;
+
+import java.security.Key;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+
+    @Value("${jwt.secret}")
+    private String secretKeyPlain;
+    private Key secretKey;
+
+    private final long ACCESS_TOKEN_EXPIRATION = 1000*60*60; //1시간
+    private final long REFRESH_TOKEN_EXPIRATION = 1000*60*60*24*7; //일주일
+
+    //임시 회원가입 토큰 만료 시간
+    private final long SIGNUP_TOKEN_EXPIRATION = 1000*60*10;
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @PostConstruct
+    protected void init() {
+        this.secretKey = Keys.hmacShaKeyFor(secretKeyPlain.getBytes());
+    }
+
+    //최초 로그인 시점에 액세스, 리프레시 토큰 모두 발급
+    //유저의 이메일을 파라미터로 사용
+    public TokenDTO createTokenDTO(String email) {
+        String accessToken = createAccessToken(email);
+        String refreshToken = createRefreshToken(email);
+        return TokenDTO.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    //액세스 토큰 생성
+    public String createAccessToken(String email){
+        return createToken(email, ACCESS_TOKEN_EXPIRATION);
+    }
+
+    //리프레시 토큰 생성
+    public String createRefreshToken(String email){
+        return createToken(email, REFRESH_TOKEN_EXPIRATION);
+    }
+
+    //토큰 생성 공통 로직
+    private String createToken(String email, long expiration) {
+        return Jwts.builder()
+                .setSubject(email)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis()+expiration))
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // 임시 토큰 생성 메소드 (providerId 기반)
+    public String createSignupToken(String providerId) {
+        return Jwts.builder()
+                .setSubject(providerId) // providerId를 subject로
+                .claim("auth", "ROLE_SIGNUP") // 임시 토큰임을 증명하는 '권한'
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + SIGNUP_TOKEN_EXPIRATION))
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // 임시 토큰 검증 및 providerId 추출
+    public String validateAndExtractProviderId(String token) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            // 'auth' 클레임 확인
+            String auth = claims.get("auth", String.class);
+            if (!"ROLE_SIGNUP".equals(auth)) {
+                throw new JwtException("Not a valid signup token (invalid auth claim)");
+            }
+
+            return claims.getSubject(); // providerId 반환
+        } catch (Exception e) { // (ExpiredJwtException, MalformedJwtException 등 모두 포함)
+            // JwtException을 사용하지 않고 SecurityException을 throw
+            throw new SecurityException("Invalid or expired signup token", e);
+        }
+    }
+
+    //토큰에서 이메일 추출
+    public String extractEmail(String token) {
+        try{
+            return Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .getSubject();
+        } catch(JwtException e){
+            return null;
+        }
+    }
+
+    //토큰 유효성 검사
+    public boolean validateToken(String token) {
+        try{
+            Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch(JwtException e){
+            return false;
+        }
+    }
+
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/global/config/security/OAuth2LoginSuccessHandler.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/global/config/security/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,60 @@
+package com.backthree.cohobby.global.config.security;
+
+import com.backthree.cohobby.domain.user.dto.TokenDTO;
+import com.backthree.cohobby.domain.user.entity.RefreshToken;
+import com.backthree.cohobby.domain.user.repository.RefreshTokenRepository;
+import com.backthree.cohobby.domain.user.entity.User;
+import com.backthree.cohobby.domain.user.repository.UserRepository;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+    private final JwtService jwtService;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException{
+        String email = authentication.getName();
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 유저입니다."));
+
+        //JWT 생성
+        TokenDTO tokenDTO = jwtService.createTokenDTO(email);
+
+        //DB에 리프레시 토큰 저장 또는 업데이트
+        refreshTokenRepository.findByUser(user)
+                .ifPresentOrElse(
+                        rt -> rt.updateToken(tokenDTO.getRefreshToken()), //이미 있으면 토큰 값만 갱신
+                        () -> refreshTokenRepository.save( //없으면 토큰 새로 생성
+                                RefreshToken.builder()
+                                        .user(user)
+                                        .token(tokenDTO.getRefreshToken())
+                                        .build())
+                );
+
+        //JWT(tokenDTO의 토큰들) 담아서 메인페이지로 리다이렉트
+        String targetUrl;
+        targetUrl = UriComponentsBuilder.fromUriString("http://localhost:3000")
+                .queryParam("accessToken", tokenDTO.getAccessToken())
+                .queryParam("refreshToken", tokenDTO.getRefreshToken())
+                .build().toUriString();
+
+        response.sendRedirect(targetUrl);
+    }
+
+    private boolean isTestProfile() {
+        String profile = System.getProperty("spring.profiles.active");
+        return "testapp".equals(profile);
+    }
+}

--- a/cohobby/src/main/java/com/backthree/cohobby/global/config/security/SecurityConfig.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/global/config/security/SecurityConfig.java
@@ -1,0 +1,57 @@
+package com.backthree.cohobby.global.config.security;
+
+import com.backthree.cohobby.domain.user.repository.RefreshTokenRepository;
+import com.backthree.cohobby.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final DefaultOAuth2UserService customOauth2UserService;
+    private final JwtService jwtService;
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable)
+                //세션을 stateless로 설정(jwt 사용을 위해)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/", "/login", "/oauth2/**", "/favicon.ico", "/css/**", "/js/**").permitAll()
+                        .requestMatchers("/auth/token/refresh").permitAll() //토큰 갱신은 누구나 접근 가능해야 함
+                        .requestMatchers("/auth/signup-extra").authenticated() //추가 정보 api는 인증 필요
+                        .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        // .loginPage("/login")
+                        .userInfoEndpoint(userInfo ->
+                                userInfo.userService(customOauth2UserService)
+                        )
+                        .successHandler(oAuth2LoginSuccessHandler())
+                )
+                //jwt 인증 필터를 oauth2 로그인 필터 실행 전에 배치
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationSuccessHandler oAuth2LoginSuccessHandler() {
+        return new OAuth2LoginSuccessHandler(jwtService, refreshTokenRepository, userRepository);
+    }
+
+}


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #이슈번호

## ✅ 작업 내용

- 작업한 주요 내용을 bullet point로 정리해주세요.
- 카카오 로그인, 로그아웃 api 구현
- jwt 인증 구현

## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.
[로그인흐름]
1. http://localhost:8080/oauth2/authorization/kakao에서 로그인
<img width="1094" height="1125" alt="image" src="https://github.com/user-attachments/assets/4477c228-7b1a-4c48-8315-c68be53a404c" />


2. 카카오 정보동의 후 인증

3. db에서 회원정보 추가된 것 확인
<img width="1167" height="452" alt="image" src="https://github.com/user-attachments/assets/6aa9fab9-c725-408e-88d9-5bcce049e756" />


4. jwt 토큰 생성 확인(refresh token 테이블)
<img width="483" height="212" alt="image" src="https://github.com/user-attachments/assets/fa1605bd-0171-41f7-aab7-709dc5451728" />



## 📎 기타 참고사항
- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.