### PR TITLE
채팅 연동 전 필요사항 수정

### DIFF
--- a/cohobby/src/main/java/com/backthree/cohobby/domain/chatting/controller/ChattingReadStompController.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/chatting/controller/ChattingReadStompController.java
@@ -2,23 +2,83 @@ package com.backthree.cohobby.domain.chatting.controller;
 
 import com.backthree.cohobby.domain.chatting.dto.ReadRequest;
 import com.backthree.cohobby.domain.chatting.service.ChattingReadService;
+import com.backthree.cohobby.domain.user.entity.User;
+import com.backthree.cohobby.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.security.Principal;
+import java.util.Map;
+
+@Slf4j
 @Controller
 @RequiredArgsConstructor
 public class ChattingReadStompController {
 
     private final ChattingReadService chattingReadService;
+    private final UserRepository userRepository;
 
     @MessageMapping("/chatting/read")
     @Transactional
-    public void read(ReadRequest req) {
-        if (req.getRoomId() == null || req.getUserId() == null || req.getLastMessageId() == null) {
-            throw new IllegalArgumentException("잘못된 읽음 요청");
+    public void read(ReadRequest req, SimpMessageHeaderAccessor headerAccessor) {
+        // 현재 로그인된 사용자 가져오기
+        User currentUser = getCurrentUser(headerAccessor);
+        if (currentUser == null) {
+            log.warn("인증되지 않은 사용자가 읽음 요청을 보내려고 시도했습니다.");
+            throw new IllegalStateException("로그인이 필요합니다!");
         }
-        chattingReadService.markRead(req.getRoomId(), req.getUserId(), req.getLastMessageId());
+
+        // 필수 필드 검증
+        if (req.getRoomId() == null || req.getLastMessageId() == null) {
+            throw new IllegalArgumentException("잘못된 읽음 요청: roomId와 lastMessageId는 필수입니다.");
+        }
+
+        // 클라이언트에서 보낸 userId가 있으면 검증 (하위 호환성)
+        if (req.getUserId() != null && !req.getUserId().equals(currentUser.getId())) {
+            log.warn("클라이언트에서 보낸 userId({})와 현재 사용자 ID({})가 일치하지 않습니다. 현재 사용자 ID를 사용합니다.", 
+                    req.getUserId(), currentUser.getId());
+        }
+
+        // 현재 사용자 ID로 읽음 처리
+        chattingReadService.markRead(req.getRoomId(), currentUser.getId(), req.getLastMessageId());
+    }
+
+    /**
+     * 현재 로그인된 사용자 가져오기
+     */
+    private User getCurrentUser(SimpMessageHeaderAccessor headerAccessor) {
+        // 1. SecurityContext에서 가져오기 시도
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof User) {
+            return (User) authentication.getPrincipal();
+        }
+
+        // 2. Principal에서 User 가져오기 시도 (UserPrincipal인 경우)
+        Principal principal = headerAccessor.getUser();
+        if (principal instanceof com.backthree.cohobby.global.config.websocket.UserPrincipal) {
+            return ((com.backthree.cohobby.global.config.websocket.UserPrincipal) principal).getUser();
+        }
+
+        // 3. 세션 속성에서 User 가져오기 시도 (WebSocketAuthInterceptor에서 저장한 값)
+        Map<String, Object> sessionAttributes = headerAccessor.getSessionAttributes();
+        if (sessionAttributes != null) {
+            Object userObj = sessionAttributes.get("user");
+            if (userObj instanceof User) {
+                return (User) userObj;
+            }
+        }
+
+        // 4. Principal의 이름으로 User 조회 시도
+        if (principal != null && principal.getName() != null) {
+            return userRepository.findByEmail(principal.getName()).orElse(null);
+        }
+
+        return null;
     }
 }

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/chatting/controller/ChattingStompController.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/chatting/controller/ChattingStompController.java
@@ -10,11 +10,16 @@ import com.backthree.cohobby.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
+import java.security.Principal;
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Slf4j
 @Controller
@@ -29,34 +34,42 @@ public class ChattingStompController {
     // 클라이언트에서 /pub/chatting/send 로 전송
     @MessageMapping("/chatting/send")
     @Transactional
-    public void sendMessage(ChattingDto message) {
+    public void sendMessage(ChattingDto message, SimpMessageHeaderAccessor headerAccessor) {
+        // 현재 로그인된 사용자 가져오기
+        User sender = getCurrentUser(headerAccessor);
+        if (sender == null) {
+            log.warn("인증되지 않은 사용자가 메시지를 보내려고 시도했습니다.");
+            throw new IllegalStateException("로그인이 필요합니다!");
+        }
+
+        // 필수 필드 검증
         if (message.getRoomId() == null ||
-                message.getSenderId() == null ||
-                message.getReceiverId() == null ||
                 message.getText() == null ||
                 message.getText().isBlank()) {
             log.warn("잘못된 메시지 payload: {}", message);
-            return;
+            throw new IllegalArgumentException("필수 필드가 누락되었습니다.");
         }
 
         ChattingRoom room = chattingRoomRepository.findById(message.getRoomId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 채팅방"));
-        User sender = userRepository.findById(message.getSenderId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 발신자"));
-        User receiver = userRepository.findById(message.getReceiverId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 수신자"));
 
-        // 참여자 검증
+        // sender가 채팅방에 속해있는지 검증
         boolean senderInRoom = room.getOwner().getId().equals(sender.getId()) ||
                 room.getBorrower().getId().equals(sender.getId());
-        boolean receiverInRoom = room.getOwner().getId().equals(receiver.getId()) ||
-                room.getBorrower().getId().equals(receiver.getId());
 
         if (!senderInRoom) {
             throw new IllegalArgumentException("채팅방에 속하지 않은 사용자");
         }
-        if (!receiverInRoom) {
-            throw new IllegalArgumentException("채팅방에 속하지 않은 사용자");
+
+        // receiver는 채팅방의 다른 사용자로 자동 설정
+        User receiver = room.getOwner().getId().equals(sender.getId()) 
+                ? room.getBorrower() 
+                : room.getOwner();
+
+        // 클라이언트에서 보낸 receiverId가 있으면 검증 (하위 호환성)
+        if (message.getReceiverId() != null && !message.getReceiverId().equals(receiver.getId())) {
+            log.warn("클라이언트에서 보낸 receiverId({})와 실제 receiverId({})가 일치하지 않습니다. 실제 receiverId를 사용합니다.", 
+                    message.getReceiverId(), receiver.getId());
         }
 
         Chatting chat = chattingRepository.save(Chatting.builder()
@@ -79,5 +92,38 @@ public class ChattingStompController {
         String destination = "/sub/chatting/room/" + room.getId();
         messagingTemplate.convertAndSend(destination, payload);
         log.debug("메시지 전송 -> {} : {}", destination, payload);
+    }
+
+    /**
+     * 현재 로그인된 사용자 가져오기
+     */
+    private User getCurrentUser(SimpMessageHeaderAccessor headerAccessor) {
+        // 1. SecurityContext에서 가져오기 시도
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof User) {
+            return (User) authentication.getPrincipal();
+        }
+
+        // 2. Principal에서 User 가져오기 시도 (UserPrincipal인 경우)
+        Principal principal = headerAccessor.getUser();
+        if (principal instanceof com.backthree.cohobby.global.config.websocket.UserPrincipal) {
+            return ((com.backthree.cohobby.global.config.websocket.UserPrincipal) principal).getUser();
+        }
+
+        // 3. 세션 속성에서 User 가져오기 시도 (WebSocketAuthInterceptor에서 저장한 값)
+        Map<String, Object> sessionAttributes = headerAccessor.getSessionAttributes();
+        if (sessionAttributes != null) {
+            Object userObj = sessionAttributes.get("user");
+            if (userObj instanceof User) {
+                return (User) userObj;
+            }
+        }
+
+        // 4. Principal의 이름으로 User 조회 시도
+        if (principal != null && principal.getName() != null) {
+            return userRepository.findByEmail(principal.getName()).orElse(null);
+        }
+
+        return null;
     }
 }

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/chatting/service/ChattingService.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/chatting/service/ChattingService.java
@@ -84,6 +84,7 @@ public class ChattingService {
 
         // 생성한 rent를 room에 설정하고 저장
         room.setRent(rent);
+        chattingRoomRepository.save(room);
 
         return ChattingRoomDto.builder()
                 .id(room.getId())

--- a/cohobby/src/main/java/com/backthree/cohobby/global/config/websocket/UserPrincipal.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/global/config/websocket/UserPrincipal.java
@@ -1,0 +1,26 @@
+package com.backthree.cohobby.global.config.websocket;
+
+import com.backthree.cohobby.domain.user.entity.User;
+
+import java.security.Principal;
+
+/**
+ * WebSocket에서 User를 Principal로 사용하기 위한 래퍼 클래스
+ */
+public class UserPrincipal implements Principal {
+    private final User user;
+
+    public UserPrincipal(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public String getName() {
+        return user.getEmail();
+    }
+
+    public User getUser() {
+        return user;
+    }
+}
+

--- a/cohobby/src/main/java/com/backthree/cohobby/global/config/websocket/WebSocketAuthInterceptor.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/global/config/websocket/WebSocketAuthInterceptor.java
@@ -1,0 +1,104 @@
+package com.backthree.cohobby.global.config.websocket;
+
+import com.backthree.cohobby.domain.user.entity.User;
+import com.backthree.cohobby.domain.user.repository.UserRepository;
+import com.backthree.cohobby.global.config.security.JwtService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.support.HttpSessionHandshakeInterceptor;
+
+import java.security.Principal;
+import java.util.Map;
+
+/**
+ * WebSocket 연결 시 JWT 토큰을 검증하고 사용자 인증 정보를 설정하는 인터셉터
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketAuthInterceptor implements ChannelInterceptor {
+
+    private final JwtService jwtService;
+    private final UserRepository userRepository;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        
+        if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
+            // CONNECT 프레임에서 토큰 추출
+            String token = extractToken(accessor);
+            
+            if (token != null && jwtService.validateToken(token)) {
+                String email = jwtService.extractEmail(token);
+                if (email != null) {
+                    User user = userRepository.findByEmail(email)
+                            .orElse(null);
+                    
+                    if (user != null) {
+                        // 인증 정보 생성
+                        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                                user, null, user.getAuthorities());
+                        SecurityContextHolder.getContext().setAuthentication(authentication);
+                        
+                        // WebSocket 세션에 사용자 정보 설정 (Principal로 설정)
+                        UserPrincipal userPrincipal = new UserPrincipal(user);
+                        accessor.setUser(userPrincipal);
+                        
+                        // 세션 속성에도 User 저장 (나중에 접근 가능하도록)
+                        Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+                        if (sessionAttributes != null) {
+                            sessionAttributes.put("user", user);
+                        }
+                        
+                        log.debug("WebSocket 인증 성공: {}", email);
+                    } else {
+                        log.warn("WebSocket 인증 실패: 사용자를 찾을 수 없음 - {}", email);
+                    }
+                }
+            } else {
+                log.warn("WebSocket 인증 실패: 유효하지 않은 토큰");
+            }
+        }
+        
+        return message;
+    }
+
+    /**
+     * STOMP 헤더나 쿼리 파라미터에서 JWT 토큰 추출
+     */
+    private String extractToken(StompHeaderAccessor accessor) {
+        // 1. Authorization 헤더에서 추출 시도
+        String authHeader = accessor.getFirstNativeHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            return authHeader.substring(7);
+        }
+        
+        // 2. 쿼리 파라미터에서 추출 시도 (WebSocket 연결 시)
+        Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+        if (sessionAttributes != null) {
+            Object tokenObj = sessionAttributes.get("token");
+            if (tokenObj instanceof String) {
+                String token = (String) tokenObj;
+                if (token.startsWith("Bearer ")) {
+                    return token.substring(7);
+                }
+                return token;
+            }
+        }
+        
+        return null;
+    }
+}
+

--- a/cohobby/src/main/java/com/backthree/cohobby/global/config/websocket/WebSocketConfig.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/global/config/websocket/WebSocketConfig.java
@@ -1,6 +1,8 @@
 package com.backthree.cohobby.global.config.websocket;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -8,16 +10,22 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final WebSocketHandshakeInterceptor webSocketHandshakeInterceptor;
+    private final WebSocketAuthInterceptor webSocketAuthInterceptor;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         // 클라이언트 접속 엔드포인트
         registry.addEndpoint("/ws-stomp")
-                .setAllowedOriginPatterns("*");
+                .setAllowedOriginPatterns("*")
+                .addInterceptors(webSocketHandshakeInterceptor);
         // SockJS 사용 클라이언트 지원
         registry.addEndpoint("/ws-stomp")
                 .setAllowedOriginPatterns("*")
+                .addInterceptors(webSocketHandshakeInterceptor)
                 .withSockJS();
     }
 
@@ -27,5 +35,11 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.setApplicationDestinationPrefixes("/pub");
         // 서버 -> 클라이언트 subscribe prefix
         registry.enableSimpleBroker("/sub");
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        // 인바운드 메시지 채널에 인증 인터셉터 등록
+        registration.interceptors(webSocketAuthInterceptor);
     }
 }

--- a/cohobby/src/main/java/com/backthree/cohobby/global/config/websocket/WebSocketHandshakeInterceptor.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/global/config/websocket/WebSocketHandshakeInterceptor.java
@@ -1,0 +1,64 @@
+package com.backthree.cohobby.global.config.websocket;
+
+import jakarta.servlet.http.HttpSession;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.net.URI;
+import java.util.Map;
+
+/**
+ * WebSocket 핸드셰이크 시 쿼리 파라미터에서 JWT 토큰을 추출하여 세션에 저장
+ */
+@Slf4j
+@Component
+public class WebSocketHandshakeInterceptor implements HandshakeInterceptor {
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                                   WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+        
+        if (request instanceof ServletServerHttpRequest) {
+            ServletServerHttpRequest servletRequest = (ServletServerHttpRequest) request;
+            
+            // 쿼리 파라미터에서 토큰 추출
+            URI uri = request.getURI();
+            String query = uri.getQuery();
+            
+            if (query != null) {
+                String[] params = query.split("&");
+                for (String param : params) {
+                    String[] keyValue = param.split("=");
+                    if (keyValue.length == 2 && "token".equals(keyValue[0])) {
+                        String token = keyValue[1];
+                        // 세션 속성에 토큰 저장 (나중에 ChannelInterceptor에서 사용)
+                        attributes.put("token", token);
+                        log.debug("WebSocket 핸드셰이크: 토큰 추출 성공");
+                        break;
+                    }
+                }
+            }
+            
+            // Authorization 헤더에서도 토큰 추출 시도
+            String authHeader = request.getHeaders().getFirst("Authorization");
+            if (authHeader != null && authHeader.startsWith("Bearer ")) {
+                attributes.put("token", authHeader);
+                log.debug("WebSocket 핸드셰이크: Authorization 헤더에서 토큰 추출");
+            }
+        }
+        
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                               WebSocketHandler wsHandler, Exception exception) {
+        // 핸드셰이크 완료 후 처리 (필요시)
+    }
+}
+


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #46 

## ✅ 작업 내용

1. WebSocket 인증 인터셉터 생성
WebSocketHandshakeInterceptor: 핸드셰이크 시 JWT 토큰 추출
WebSocketAuthInterceptor: CONNECT 프레임에서 JWT 검증 및 사용자 인증
UserPrincipal: User를 Principal로 사용하기 위한 래퍼 클래스
2. WebSocketConfig 수정
HandshakeInterceptor와 ChannelInterceptor 등록
인바운드 메시지 채널에 인증 인터셉터 적용
3. ChattingStompController 수정
senderId를 클라이언트에서 받지 않고 서버에서 현재 로그인된 사용자로 자동 설정
receiverId를 채팅방의 다른 사용자로 자동 설정
클라이언트에서 보낸 senderId/receiverId는 무시하고 서버 값 사용
4. ChattingReadStompController 수정
userId를 클라이언트에서 받지 않고 서버에서 현재 로그인된 사용자로 자동 설정
인증되지 않은 사용자 요청 차단
