### PR TITLE
feat: 대여정보 조회 api 구현

### DIFF
--- a/cohobby/src/main/java/com/backthree/cohobby/domain/rent/controller/RentController.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/rent/controller/RentController.java
@@ -1,6 +1,7 @@
 package com.backthree.cohobby.domain.rent.controller;
 
 import com.backthree.cohobby.domain.rent.dto.request.UpdateDetailRequest;
+import com.backthree.cohobby.domain.rent.dto.response.RentDetailResponse;
 import com.backthree.cohobby.domain.rent.dto.response.UpdateDetailResponse;
 import com.backthree.cohobby.domain.rent.service.RentService;
 import com.backthree.cohobby.domain.user.entity.User;
@@ -16,6 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,6 +30,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class RentController {
     private final RentService rentService;
+
+    @Operation(summary = "대여 정보 조회 API", description = "roomId로 대여 정보를 조회합니다")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "대여 정보 조회 성공")
+    })
+    @ErrorDocs({ErrorStatus.USER_NOT_FOUND})
+    @GetMapping("/{roomId}/detail")
+    public BaseResponse<RentDetailResponse> getRentDetail(
+            @PathVariable Long roomId,
+            @Parameter(hidden = true) @CurrentUser User user
+    ) {
+        RentDetailResponse payload = rentService.getRentDetail(roomId, user.getId());
+        return BaseResponse.onSuccess(SuccessStatus._OK, payload);
+    }
 
     @Operation(summary = "대여 정보 수정 API", description = "대여 날짜, 대여 규칙 중 하나만 body에 넣어야함")
     @ApiResponses({

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/rent/dto/response/RentDetailResponse.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/rent/dto/response/RentDetailResponse.java
@@ -1,0 +1,36 @@
+package com.backthree.cohobby.domain.rent.dto.response;
+
+import com.backthree.cohobby.domain.rent.entity.Rent;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class RentDetailResponse {
+    private Long id;
+    private LocalDateTime startAt;
+    private LocalDateTime duedate;
+    private String rule;
+    private String status;
+    private Integer totalPrice;
+    private String currency;
+    private Long postId;
+    private String postGoods;
+
+    public static RentDetailResponse fromEntity(Rent rent) {
+        return RentDetailResponse.builder()
+                .id(rent.getId())
+                .startAt(rent.getStartAt())
+                .duedate(rent.getDuedate())
+                .rule(rent.getRule())
+                .status(rent.getStatus() != null ? rent.getStatus().name() : null)
+                .totalPrice(rent.getTotalPrice())
+                .currency(rent.getCurrency())
+                .postId(rent.getPost() != null ? rent.getPost().getId() : null)
+                .postGoods(rent.getPost() != null ? rent.getPost().getGoods() : null)
+                .build();
+    }
+}
+

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/rent/service/RentService.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/rent/service/RentService.java
@@ -1,6 +1,7 @@
 package com.backthree.cohobby.domain.rent.service;
 
 import com.backthree.cohobby.domain.rent.dto.request.UpdateDetailRequest;
+import com.backthree.cohobby.domain.rent.dto.response.RentDetailResponse;
 import com.backthree.cohobby.domain.rent.dto.response.UpdateDetailResponse;
 import com.backthree.cohobby.domain.rent.entity.Rent;
 import com.backthree.cohobby.domain.rent.repository.RentRepository;
@@ -15,6 +16,19 @@ import java.time.LocalDateTime;
 public class RentService {
 
     private final RentRepository rentRepository;
+
+    @Transactional(readOnly = true)
+    public RentDetailResponse getRentDetail(Long roomId, Long userId) {
+        Rent rent = rentRepository.findByChattingRoomId(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("대여 정보를 찾을 수 없습니다. roomId=" + roomId));
+        
+        // 권한 검증: owner 또는 borrower만 조회 가능
+        if (!rent.getOwner().getId().equals(userId) && !rent.getBorrower().getId().equals(userId)) {
+            throw new IllegalArgumentException("대여 정보를 조회할 권한이 없습니다.");
+        }
+
+        return RentDetailResponse.fromEntity(rent);
+    }
 
     @Transactional
     public UpdateDetailResponse updateDetail(Long roomId, UpdateDetailRequest request, Long userId) {


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #64 

## ✅ 작업 내용

- '결제하기' 페이지 처음에 표시될 대여 정보를 표시하는 api 구현
- 채팅창에서 넘어오기 때문에 roomId 입력받아 해당하는 대여 정보를 가져오도록 함

## 📸 스크린샷

<img width="1548" height="1125" alt="image" src="https://github.com/user-attachments/assets/b6b93c7c-2ded-40aa-b643-ba905c40e312" />


## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.