### PR TITLE
fix: 게시글 목록에 이미지 뜨도록 수정

### DIFF
--- a/cohobby/src/main/java/com/backthree/cohobby/domain/post/controller/PostController.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/post/controller/PostController.java
@@ -19,7 +19,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
@@ -126,6 +125,8 @@ public class PostController {
     ) {
         Long userId = getCurrentUserId();
         List<Post> posts = postQueryService.getPosts(query, "search", userId);
+        // Image 엔티티 로딩 (LAZY 로딩을 위해)
+        posts.forEach(post -> post.getImages().size());
         List<GetPostResponse> response = posts.stream()
                 .map(GetPostResponse::fromEntity)
                 .collect(Collectors.toList());
@@ -143,6 +144,8 @@ public class PostController {
     ) {
         Long userId = getCurrentUserId();
         List<Post> posts = postQueryService.getPosts(String.valueOf(categoryId), "category", userId);
+        // Image 엔티티 로딩 (LAZY 로딩을 위해)
+        posts.forEach(post -> post.getImages().size());
         List<GetPostResponse> response = posts.stream()
                 .map(GetPostResponse::fromEntity)
                 .collect(Collectors.toList());
@@ -160,6 +163,8 @@ public class PostController {
     ) {
         Long userId = getCurrentUserId();
         List<Post> posts = postQueryService.getPosts(String.valueOf(hobbyId), "hobby", userId);
+        // Image 엔티티 로딩 (LAZY 로딩을 위해)
+        posts.forEach(post -> post.getImages().size());
         List<GetPostResponse> response = posts.stream()
                 .map(GetPostResponse::fromEntity)
                 .collect(Collectors.toList());

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/post/dto/response/GetPostResponse.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/post/dto/response/GetPostResponse.java
@@ -44,12 +44,27 @@ public class GetPostResponse {
     private String userNickname;
 
     public static GetPostResponse fromEntity(Post post) {
+        // 이미지 URL 추출: Image 엔티티의 첫 번째 이미지를 우선 사용, 없으면 post.imageUrl 사용
+        String imageUrl = null;
+        if (post.getImages() != null && !post.getImages().isEmpty()) {
+            // Image 엔티티에서 첫 번째 이미지 URL 가져오기
+            imageUrl = post.getImages().stream()
+                    .filter(image -> image.getImageUrl() != null)
+                    .map(image -> image.getImageUrl())
+                    .findFirst()
+                    .orElse(null);
+        }
+        // Image 엔티티에 이미지가 없으면 post.imageUrl 사용
+        if (imageUrl == null) {
+            imageUrl = post.getImageUrl();
+        }
+
         return GetPostResponse.builder()
                 .postId(post.getId())
                 .goods(post.getGoods())
                 .dailyPrice(post.getDailyPrice())
                 .deposit(post.getDeposit())
-                .imageUrl(post.getImageUrl())
+                .imageUrl(imageUrl)
                 .availableFrom(post.getAvailableFrom())
                 .availableUntil(post.getAvailableUntil())
                 .hobbyName(post.getHobby() != null ? post.getHobby().getName() : null)


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #이슈번호

## ✅ 작업 내용

- 게시글 목록에 등록된 이미지 중 첫번째 url 가져와서 띄우도록 api 수정

## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.