### PR TITLE
찜 api 구현

### DIFF
--- a/cohobby/src/main/java/com/backthree/cohobby/domain/like/dto/response/CreateLikeResponse.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/like/dto/response/CreateLikeResponse.java
@@ -1,0 +1,27 @@
+package com.backthree.cohobby.domain.like.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CreateLikeResponse {
+    @Schema(description = "찜 ID", example = "1")
+    private Long likeId;
+    
+    @Schema(description = "게시물 ID", example = "123")
+    private Long postId;
+    
+    @Schema(description = "메시지", example = "찜이 성공적으로 생성되었습니다.")
+    private String message;
+    
+    public static CreateLikeResponse from(Long likeId, Long postId) {
+        return CreateLikeResponse.builder()
+                .likeId(likeId)
+                .postId(postId)
+                .message("찜이 성공적으로 생성되었습니다.")
+                .build();
+    }
+}
+

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/like/dto/response/DeleteLikeResponse.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/like/dto/response/DeleteLikeResponse.java
@@ -1,0 +1,23 @@
+package com.backthree.cohobby.domain.like.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DeleteLikeResponse {
+    @Schema(description = "게시물 ID", example = "123")
+    private Long postId;
+    
+    @Schema(description = "메시지", example = "찜이 성공적으로 취소되었습니다.")
+    private String message;
+    
+    public static DeleteLikeResponse from(Long postId) {
+        return DeleteLikeResponse.builder()
+                .postId(postId)
+                .message("찜이 성공적으로 취소되었습니다.")
+                .build();
+    }
+}
+

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/like/entity/Like.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/like/entity/Like.java
@@ -1,5 +1,6 @@
 package com.backthree.cohobby.domain.like.entity;
 
+import com.backthree.cohobby.domain.common.BaseTimeEntity;
 import com.backthree.cohobby.domain.post.entity.Post;
 import com.backthree.cohobby.domain.user.entity.User;
 import jakarta.persistence.*;
@@ -11,7 +12,7 @@ import lombok.Setter;
 @Entity
 @Table(name = "likes",
         uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "post_id"}))
-public class Like {
+public class Like extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/like/repository/LikeRepository.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/like/repository/LikeRepository.java
@@ -1,7 +1,17 @@
 package com.backthree.cohobby.domain.like.repository;
 
 import com.backthree.cohobby.domain.like.entity.Like;
+import com.backthree.cohobby.domain.post.entity.Post;
+import com.backthree.cohobby.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface LikeRepository extends JpaRepository<Like, Long> {
+    Optional<Like> findByUserAndPost(User user, Post post);
+    
+    List<Like> findByUserOrderByCreatedAtDesc(User user);
+    
+    boolean existsByUserAndPost(User user, Post post);
 }

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/like/service/LikeService.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/like/service/LikeService.java
@@ -1,6 +1,7 @@
 package com.backthree.cohobby.domain.like.service;
 
 import com.backthree.cohobby.domain.like.dto.response.CreateLikeResponse;
+import com.backthree.cohobby.domain.like.dto.response.DeleteLikeResponse;
 import com.backthree.cohobby.domain.like.entity.Like;
 import com.backthree.cohobby.domain.like.repository.LikeRepository;
 import com.backthree.cohobby.domain.post.dto.response.GetPostResponse;
@@ -47,7 +48,7 @@ public class LikeService {
     }
 
     @Transactional
-    public void deleteLike(Long postId, Long userId) {
+    public DeleteLikeResponse deleteLike(Long postId, Long userId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
         
@@ -58,6 +59,8 @@ public class LikeService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.LIKE_NOT_FOUND));
         
         likeRepository.delete(like);
+        
+        return DeleteLikeResponse.from(postId);
     }
 
     @Transactional(readOnly = true)

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/like/service/LikeService.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/like/service/LikeService.java
@@ -1,0 +1,103 @@
+package com.backthree.cohobby.domain.like.service;
+
+import com.backthree.cohobby.domain.like.dto.response.CreateLikeResponse;
+import com.backthree.cohobby.domain.like.entity.Like;
+import com.backthree.cohobby.domain.like.repository.LikeRepository;
+import com.backthree.cohobby.domain.post.dto.response.GetPostResponse;
+import com.backthree.cohobby.domain.post.entity.Post;
+import com.backthree.cohobby.domain.post.repository.PostRepository;
+import com.backthree.cohobby.domain.user.entity.User;
+import com.backthree.cohobby.domain.user.repository.UserRepository;
+import com.backthree.cohobby.global.common.response.status.ErrorStatus;
+import com.backthree.cohobby.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+    private final LikeRepository likeRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public CreateLikeResponse createLike(Long postId, Long userId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+        
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        
+        // 이미 찜한 게시물인지 확인
+        if (likeRepository.existsByUserAndPost(user, post)) {
+            throw new GeneralException(ErrorStatus.LIKE_ALREADY_EXISTS);
+        }
+        
+        Like like = new Like();
+        like.setUser(user);
+        like.setPost(post);
+        
+        Like savedLike = likeRepository.save(like);
+        
+        return CreateLikeResponse.from(savedLike.getId(), postId);
+    }
+
+    @Transactional
+    public void deleteLike(Long postId, Long userId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+        
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        
+        Like like = likeRepository.findByUserAndPost(user, post)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.LIKE_NOT_FOUND));
+        
+        likeRepository.delete(like);
+    }
+
+    @Transactional(readOnly = true)
+    public List<GetPostResponse> getMyLikes(Long userId, Long categoryId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        
+        // 전체 찜 목록 조회
+        List<Like> likes = likeRepository.findByUserOrderByCreatedAtDesc(user);
+        
+        // Image 엔티티 로딩 (LAZY 로딩을 위해)
+        likes.forEach(like -> {
+            if (like.getPost() != null) {
+                Post post = like.getPost();
+                // Post의 Hobby와 Category 로딩
+                if (post.getHobby() != null) {
+                    post.getHobby().getCategory();
+                }
+                if (post.getImages() != null) {
+                    post.getImages().size();
+                }
+            }
+        });
+        
+        // 카테고리 필터링 (서비스 레이어에서 처리)
+        return likes.stream()
+                .map(Like::getPost)
+                .filter(post -> post != null)
+                .filter(post -> {
+                    // categoryId가 null이면 모든 게시물 반환
+                    if (categoryId == null) {
+                        return true;
+                    }
+                    // categoryId가 있으면 해당 카테고리만 필터링
+                    return post.getHobby() != null 
+                            && post.getHobby().getCategory() != null
+                            && post.getHobby().getCategory().getId().equals(categoryId);
+                })
+                .map(GetPostResponse::fromEntity)
+                .collect(Collectors.toList());
+    }
+}
+

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/post/controller/PostController.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/post/controller/PostController.java
@@ -4,6 +4,7 @@ import com.backthree.cohobby.domain.post.dto.request.*;
 import com.backthree.cohobby.domain.post.dto.response.*;
 import com.backthree.cohobby.domain.post.entity.Post;
 import com.backthree.cohobby.domain.like.dto.response.CreateLikeResponse;
+import com.backthree.cohobby.domain.like.dto.response.DeleteLikeResponse;
 import com.backthree.cohobby.domain.like.service.LikeService;
 import com.backthree.cohobby.domain.post.service.AIEstimateService;
 import com.backthree.cohobby.domain.post.service.PostQueryService;
@@ -207,5 +208,20 @@ public class PostController {
     ) {
         CreateLikeResponse payload = likeService.createLike(postId, user.getId());
         return BaseResponse.onSuccess(SuccessStatus._CREATED, payload);
+    }
+
+    @Operation(summary = "게시물 찜 취소", description = "특정 게시물의 찜을 취소합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "찜 취소 성공"),
+    })
+    @ErrorDocs({ErrorStatus.POST_NOT_FOUND, ErrorStatus.USER_NOT_FOUND, ErrorStatus.LIKE_NOT_FOUND})
+    @DeleteMapping("/{postId}/likes")
+    public BaseResponse<DeleteLikeResponse> deleteLike(
+            @Parameter(description = "게시물 ID", example = "1")
+            @PathVariable Long postId,
+            @Parameter(hidden = true) @CurrentUser User user
+    ) {
+        DeleteLikeResponse payload = likeService.deleteLike(postId, user.getId());
+        return BaseResponse.onSuccess(SuccessStatus._OK, payload);
     }
 }

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/user/controller/UserController.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/user/controller/UserController.java
@@ -1,22 +1,53 @@
 package com.backthree.cohobby.domain.user.controller;
 
+import com.backthree.cohobby.domain.like.service.LikeService;
+import com.backthree.cohobby.domain.post.dto.response.GetPostResponse;
 import com.backthree.cohobby.domain.user.dto.UserResponseDTO;
+import com.backthree.cohobby.domain.user.entity.User;
 import com.backthree.cohobby.domain.user.service.UserService;
-import com.backthree.cohobby.global.common.response.status.ErrorStatus;
-import com.backthree.cohobby.global.exception.GeneralException;
+import com.backthree.cohobby.global.annotation.CurrentUser;
+import com.backthree.cohobby.global.common.BaseResponse;
+import com.backthree.cohobby.global.common.response.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
+@Tag(name="User", description = "사용자 관련 API")
 @RestController
 @RequestMapping("/users")
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
+    private final LikeService likeService;
 
+    @Operation(summary = "사용자 프로필 조회", description = "사용자 ID로 프로필 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "사용자 프로필 조회 성공"),
+    })
     @GetMapping("/{userId}")
     public ResponseEntity<UserResponseDTO> getUserProfile(@PathVariable Long userId) {
         return ResponseEntity.ok(UserResponseDTO.from(userService.findUserById(userId)));
+    }
+
+    @Operation(summary = "내가 찜한 게시글 목록 조회", description = "현재 사용자가 찜한 게시물 목록을 조회합니다. 카테고리 ID를 선택적으로 제공하면 해당 카테고리별로 필터링됩니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "찜한 게시물 조회 성공"),
+    })
+    @GetMapping("/my-likes")
+    public BaseResponse<List<GetPostResponse>> getMyLikes(
+            @Parameter(description = "카테고리 ID (선택사항)", example = "1")
+            @RequestParam(required = false) Long categoryId,
+            @Parameter(hidden = true) @CurrentUser User user
+    ) {
+        List<GetPostResponse> response = likeService.getMyLikes(user.getId(), categoryId);
+        return BaseResponse.onSuccess(SuccessStatus._OK, response);
     }
 }
 

--- a/cohobby/src/main/java/com/backthree/cohobby/global/common/response/status/ErrorStatus.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/global/common/response/status/ErrorStatus.java
@@ -36,7 +36,11 @@ public enum ErrorStatus implements BaseCode {
     // 이미지 관련 에러
     INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "FILE4001", "잘못된 파일 확장자입니다."),
     NOT_IMAGE_FILE(HttpStatus.BAD_REQUEST, "FILE4002", "이미지 파일만 업로드 가능합니다."),
-    S3_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FILE5001", "이미지 업로드 중 소버 오류가 발생했습니다.");
+    S3_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FILE5001", "이미지 업로드 중 소버 오류가 발생했습니다."),
+
+    // 찜 관련 에러
+    LIKE_ALREADY_EXISTS(HttpStatus.CONFLICT, "LIKE4091", "이미 찜한 게시물입니다."),
+    LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "LIKE4041", "찜한 내역을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #이슈번호

## ✅ 작업 내용

- 작업한 주요 내용을 bullet point로 정리해주세요.
- 찜 생성, 취소 api 구현
- 내가 찜한 게시글 목록 카테고리별로 조회하는 api 구현(마이페이지에서 조회)

## 📸 스크린샷

[찜 생성]
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/a0dc2eea-4597-4fd3-a0a0-b5cdb6d83326" />
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/efcf0d54-7987-44ec-8478-72e1995ff18c" />


[찜 취소]
<img width="800" alt="image" src="https://github.com/user-attachments/assets/93788fd5-8c22-4f14-b0c7-9029218fba9e" />
<img width="800" alt="image" src="https://github.com/user-attachments/assets/6fbe624c-fc84-488f-8ad4-2002820c9d98" />
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/d134ddd3-0499-4577-b29a-6543c14445b3" />

[찜 목록 조회]
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/86ec4db7-4517-48b2-869d-573a79943179" />


## 📎 기타 참고사항

- 프론트 연동 필요