### PR TITLE
fix: 로그인 api 관리자/사용자로 분기

### DIFF
--- a/cohobby/src/main/java/com/backthree/cohobby/domain/user/controller/AuthController.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/user/controller/AuthController.java
@@ -3,11 +3,13 @@ package com.backthree.cohobby.domain.user.controller;
 import com.backthree.cohobby.domain.user.dto.TokenDTO;
 import com.backthree.cohobby.domain.user.dto.TokenRefreshRequestDTO;
 import com.backthree.cohobby.domain.user.dto.UserResponseDTO;
+import com.backthree.cohobby.domain.user.dto.request.AdminLoginRequest;
 import com.backthree.cohobby.domain.user.dto.request.TestLoginRequest;
 import com.backthree.cohobby.domain.user.dto.request.TestSignupRequest;
 import com.backthree.cohobby.domain.user.entity.User;
 import com.backthree.cohobby.domain.user.repository.RefreshTokenRepository;
 import com.backthree.cohobby.domain.user.repository.UserRepository;
+import com.backthree.cohobby.domain.user.service.AdminAuthService;
 import com.backthree.cohobby.domain.user.service.TestAuthService;
 import com.backthree.cohobby.global.annotation.CurrentUser;
 import com.backthree.cohobby.global.config.security.JwtService;
@@ -27,6 +29,7 @@ public class AuthController {
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final TestAuthService testAuthService;
+    private final AdminAuthService adminAuthService;
 
     /*@PostMapping("/signup-extra")
     public ResponseEntity<String> handleForm(@RequestBody SignupExtraDTO dto,
@@ -90,6 +93,13 @@ public class AuthController {
     @PostMapping("/test/login")
     public ResponseEntity<TokenDTO> testLogin(@RequestBody TestLoginRequest request) {
         TokenDTO tokenDTO = testAuthService.login(request);
+        return ResponseEntity.ok(tokenDTO);
+    }
+
+    // 관리자 로그인
+    @PostMapping("/admin/login")
+    public ResponseEntity<TokenDTO> adminLogin(@RequestBody AdminLoginRequest request) {
+        TokenDTO tokenDTO = adminAuthService.adminLogin(request);
         return ResponseEntity.ok(tokenDTO);
     }
 

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/user/dto/UserResponseDTO.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/user/dto/UserResponseDTO.java
@@ -19,6 +19,7 @@ public class UserResponseDTO {
     private Integer birthYear;
     private LocalDate birthday;
     private String phoneNumber;
+    private String role;
     private LocalDateTime createdAt;
 
     public static UserResponseDTO from(User user) {
@@ -32,6 +33,7 @@ public class UserResponseDTO {
                 .birthYear(user.getBirthYear())
                 .birthday(user.getBirthday())
                 .phoneNumber(user.getPhoneNumber())
+                .role(user.getRole() != null ? user.getRole().name() : "USER")
                 .createdAt(user.getCreatedAt())
                 .build();
     }

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/user/dto/request/AdminLoginRequest.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/user/dto/request/AdminLoginRequest.java
@@ -1,0 +1,10 @@
+package com.backthree.cohobby.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AdminLoginRequest(
+        @NotBlank(message = "이메일은 필수 입력 값입니다.")
+        String email
+) {
+}
+

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/user/service/AdminAuthService.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/user/service/AdminAuthService.java
@@ -1,0 +1,60 @@
+package com.backthree.cohobby.domain.user.service;
+
+import com.backthree.cohobby.domain.user.dto.TokenDTO;
+import com.backthree.cohobby.domain.user.dto.request.AdminLoginRequest;
+import com.backthree.cohobby.domain.user.entity.RefreshToken;
+import com.backthree.cohobby.domain.user.entity.Role;
+import com.backthree.cohobby.domain.user.entity.User;
+import com.backthree.cohobby.domain.user.repository.RefreshTokenRepository;
+import com.backthree.cohobby.domain.user.repository.UserRepository;
+import com.backthree.cohobby.global.config.security.JwtService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminAuthService {
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtService jwtService;
+
+    // 관리자 로그인
+    public TokenDTO adminLogin(AdminLoginRequest request) {
+        // 사용자 조회
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다: " + request.email()));
+
+        // 관리자 권한 확인
+        if (user.getRole() == null || user.getRole() != Role.ADMIN) {
+            throw new IllegalArgumentException("관리자 권한이 없습니다.");
+        }
+
+        // 계정이 비활성화되었는지 확인
+        if (user.getIsBanned()) {
+            throw new IllegalArgumentException("비활성화된 계정입니다.");
+        }
+
+        // JWT 토큰 생성
+        TokenDTO tokenDTO = jwtService.createTokenDTO(request.email());
+
+        // 리프레시 토큰 업데이트 또는 생성
+        refreshTokenRepository.findByUser(user)
+                .ifPresentOrElse(
+                        rt -> rt.updateToken(tokenDTO.getRefreshToken()),
+                        () -> refreshTokenRepository.save(
+                                RefreshToken.builder()
+                                        .user(user)
+                                        .token(tokenDTO.getRefreshToken())
+                                        .build()
+                        )
+                );
+
+        log.info("관리자 로그인 완료: email={}", request.email());
+        return tokenDTO;
+    }
+}
+

--- a/cohobby/src/main/java/com/backthree/cohobby/global/config/security/SecurityConfig.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/global/config/security/SecurityConfig.java
@@ -53,6 +53,7 @@ public class SecurityConfig {
                         .requestMatchers("/", "/login", "/oauth2/**", "/favicon.ico", "/css/**", "/js/**").permitAll()
                         .requestMatchers("/auth/token/refresh").permitAll() //토큰 갱신은 누구나 접근 가능해야 함
                         .requestMatchers("/auth/test/**").permitAll() // 테스트용 회원가입/로그인 API
+                        .requestMatchers("/auth/admin/login").permitAll() // 관리자 로그인 API
                         .requestMatchers("/swagger-ui/**", "/docs/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll() // Swagger UI는 인증 필요
                         .requestMatchers("/ws-stomp/**").permitAll() // WebSocket 핸드셰이크 허용 (실제 인증은 STOMP CONNECT에서 처리)
                         .requestMatchers("/auth/signup-extra").authenticated() //추가 정보 api는 인증 필요


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #이슈번호

## ✅ 작업 내용

- 로그인 api를 사용자/관리자용으로 나누어 구현

## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.