### PR TITLE
fix: 신고 이미지 타입 변경

### DIFF
--- a/cohobby/src/main/java/com/backthree/cohobby/domain/report/controller/ReportController.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/report/controller/ReportController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -25,9 +26,9 @@ public class ReportController {
     private final ReportService reportService;
 
     @Operation(summary = "신고 생성", description = "대여 관련 신고를 생성합니다.")
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<BaseResponse<ReportResponse>> createReport(
-            @Valid @RequestBody CreateReportRequest request,
+            @Valid @ModelAttribute CreateReportRequest request,
             @Parameter(hidden = true) @CurrentUser User user
     ) {
         ReportResponse response = reportService.createReport(request, user);

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/report/dto/request/CreateReportRequest.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/report/dto/request/CreateReportRequest.java
@@ -4,8 +4,12 @@ import com.backthree.cohobby.domain.report.entity.ReportType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Getter
 @Setter
@@ -26,8 +30,9 @@ public class CreateReportRequest {
     @NotBlank(message = "신고 내용은 필수 입력 값입니다.")
     private String content;
 
-    @Schema(description = "이미지 URL", example = "https://example.com/image.jpg")
-    private String imageUrl;
+    @Schema(description = "이미지 파일 목록 (S3 업로드, 최대 5개)")
+    @Size(max = 5, message = "이미지는 최대 5개까지 업로드할 수 있습니다.")
+    private List<MultipartFile> images;
 
     @Schema(description = "연체일수 (반납 연체 신고 시 필수)", example = "3")
     private Integer delayDays;

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/report/dto/response/ReportResponse.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/report/dto/response/ReportResponse.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Builder
@@ -18,7 +19,7 @@ public class ReportResponse {
     private String content;
     private ReportType type;
     private ReportStatus status;
-    private String imageUrl;
+    private List<String> imageUrls;
     private Integer delayDays;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
@@ -32,7 +33,7 @@ public class ReportResponse {
                 .content(report.getContent())
                 .type(report.getType())
                 .status(report.getStatus())
-                .imageUrl(report.getImageUrl())
+                .imageUrls(report.getImageUrls())
                 .delayDays(report.getDelayDays())
                 .createdAt(report.getCreatedAt())
                 .updatedAt(report.getUpdatedAt())

--- a/cohobby/src/main/java/com/backthree/cohobby/domain/report/entity/Report.java
+++ b/cohobby/src/main/java/com/backthree/cohobby/domain/report/entity/Report.java
@@ -8,6 +8,8 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -30,8 +32,11 @@ public class Report extends BaseTimeEntity {
     @Column(length = 50)
     private ReportType type;   // ENUM → String
 
-    @Column(name = "image_url", length = 127)
-    private String imageUrl;
+    @ElementCollection
+    @CollectionTable(name = "report_image_urls", joinColumns = @JoinColumn(name = "report_id"))
+    @Column(name = "image_url", length = 500)
+    @Builder.Default
+    private List<String> imageUrls = new ArrayList<>();
 
     @ManyToOne(fetch=FetchType.LAZY)
     @JoinColumn(name = "rentId", nullable = false)


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #이슈번호

## ✅ 작업 내용

- 신고할 때 이미지 삽입 - url에서 multipart form data로 변경하고 s3에 저장하도록 수정함

## 📸 스크린샷
<img width="1968" height="1125" alt="image" src="https://github.com/user-attachments/assets/b2751c15-deaa-4c39-a0f3-24d590c38548" />
<img width="2000" height="705" alt="image" src="https://github.com/user-attachments/assets/7b7b9b31-ad2c-4121-95de-dc095378f77c" />
[db]
<img width="1061" height="329" alt="image" src="https://github.com/user-attachments/assets/f3db3ef2-d273-4f1f-9e11-a7b203b5ec30" />


## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.